### PR TITLE
remove issue-specific code analysis from script auditor

### DIFF
--- a/Editor/BoxingAnalyzer.cs
+++ b/Editor/BoxingAnalyzer.cs
@@ -19,7 +19,7 @@ namespace Unity.ProjectAuditor.Editor
             solution = "Try to avoid Boxing when possible."
         };
 
-        private OpCode[] m_OpCoCodes = new[] {OpCodes.Box};
+        private OpCode[] m_OpCodes = new[] {OpCodes.Box};
         
         public BoxingAnalyzer(ScriptAuditor auditor)
         {
@@ -67,7 +67,7 @@ namespace Unity.ProjectAuditor.Editor
 
         public IEnumerable<OpCode> GetOpCodes()
         {
-            return m_OpCoCodes;
+            return m_OpCodes;
         }
     }
 }

--- a/Editor/CallAnalyzer.cs
+++ b/Editor/CallAnalyzer.cs
@@ -9,7 +9,7 @@ namespace Unity.ProjectAuditor.Editor
     public class CallAnalyzer : IInstructionAnalyzer
     {
         private IEnumerable<ProblemDescriptor> m_Descriptors;
-        private OpCode[] m_OpCoCodes = new[] {OpCodes.Call, OpCodes.Callvirt};
+        private OpCode[] m_OpCodes = new[] {OpCodes.Call, OpCodes.Callvirt};
 
         public CallAnalyzer(ScriptAuditor auditor)
         {
@@ -59,7 +59,7 @@ namespace Unity.ProjectAuditor.Editor
 
         public IEnumerable<OpCode> GetOpCodes()
         {
-            return m_OpCoCodes;
+            return m_OpCodes;
         }
     }
 }

--- a/Editor/CallAnalyzer.cs
+++ b/Editor/CallAnalyzer.cs
@@ -1,0 +1,65 @@
+using System.Collections.Generic;
+using System.Linq;
+using Mono.Cecil;
+using Mono.Cecil.Cil;
+
+namespace Unity.ProjectAuditor.Editor
+{
+    [ScriptAnalyzer]
+    public class CallAnalyzer : IInstructionAnalyzer
+    {
+        private IEnumerable<ProblemDescriptor> m_Descriptors;
+        private OpCode[] m_OpCoCodes = new[] {OpCodes.Call, OpCodes.Callvirt};
+
+        public CallAnalyzer(ScriptAuditor auditor)
+        {
+            m_Descriptors = auditor.GetDescriptors();
+        }
+        
+        public ProjectIssue Analyze(Instruction inst)
+        {
+            var callee = ((MethodReference) inst.Operand);
+
+            // replace root with callee node
+            var calleeNode = new CallTreeNode(callee);
+            
+            var description = string.Empty;
+            var descriptor = m_Descriptors.SingleOrDefault(c => c.type == callee.DeclaringType.FullName &&
+                                                                       (c.method == callee.Name ||
+                                                                        ("get_" + c.method) == callee.Name));
+
+            if (descriptor != null)
+            {
+                // by default use descriptor issue description
+                description = descriptor.description;
+            }
+            else
+            {
+                // Are we trying to warn about a whole namespace?
+                descriptor = m_Descriptors.SingleOrDefault(c =>
+                    c.type == callee.DeclaringType.Namespace && c.method == "*");
+                if (descriptor == null)
+                {
+                    // no issue found
+                    return null;
+                }
+                
+                // use callee name since it's more informative
+                description = calleeNode.prettyName;
+            }
+
+            return new ProjectIssue
+            {
+                description = description,
+                category = IssueCategory.ApiCalls,
+                descriptor = descriptor,
+                callTree = calleeNode
+            };
+        }
+
+        public IEnumerable<OpCode> GetOpCodes()
+        {
+            return m_OpCoCodes;
+        }
+    }
+}

--- a/Editor/CallAnalyzer.cs.meta
+++ b/Editor/CallAnalyzer.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: ac08859b2f0974b97925f25d89a4ed4a
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Editor/CallTreeNode.cs
+++ b/Editor/CallTreeNode.cs
@@ -83,7 +83,12 @@ namespace Unity.ProjectAuditor.Editor
         {
             return children != null && children.Count > 0;
         }
-        
+
+        public void AddChild(CallTreeNode child)
+        {
+            children.Add(child);
+        }
+
         public CallTreeNode GetChild(int index = 0)
         {
             return children[index];

--- a/Editor/IInstructionAnalyzer.cs
+++ b/Editor/IInstructionAnalyzer.cs
@@ -1,0 +1,12 @@
+using System.Collections.Generic;
+using Mono.Cecil.Cil;
+
+namespace Unity.ProjectAuditor.Editor
+{
+    public interface IInstructionAnalyzer
+    {
+        ProjectIssue Analyze(Instruction inst);
+
+        IEnumerable<OpCode> GetOpCodes();
+    }
+}

--- a/Editor/IInstructionAnalyzer.cs.meta
+++ b/Editor/IInstructionAnalyzer.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 2efd86d12bead4a4abd4fe3ca59cb536
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Editor/ProjectReport.cs
+++ b/Editor/ProjectReport.cs
@@ -38,7 +38,7 @@ namespace Unity.ProjectAuditor.Editor
         public void Export(string path)
         {
             StreamWriter writer = new StreamWriter(path);
-            writer.WriteLine("Issue,Area,Details,Path,Line");
+            writer.WriteLine("Issue,Area,Path,Line");
 
             for (int i = 0; i < (int) IssueCategory.NumCategories; i++)
             {
@@ -48,10 +48,9 @@ namespace Unity.ProjectAuditor.Editor
                 foreach (var issue in issues)
                 {
                     writer.WriteLine(
-                        issue.descriptor.description + "," +
+                        issue.description + "," +
                         issue.descriptor.area + "," +
-                        issue.name + "," +
-                        issue.relativePath + "," +
+                            issue.relativePath + "," +
                         issue.line);
                 }
             }

--- a/Editor/ScriptAuditor.cs
+++ b/Editor/ScriptAuditor.cs
@@ -17,8 +17,9 @@ namespace Unity.ProjectAuditor.Editor
 {
     public class ScriptAuditor : IAuditor
     {
+        private List<IInstructionAnalyzer> m_InstructionAnalyzers = new List<IInstructionAnalyzer>();
         private List<ProblemDescriptor> m_ProblemDescriptors;
-        private ProblemDescriptor[] m_ProblemsDefinedByOpCode;
+        private List<OpCode> m_OpCoCodes = new List<OpCode>();
         
         private UnityEditor.Compilation.Assembly[] m_PlayerAssemblies;
 
@@ -139,10 +140,9 @@ namespace Unity.ProjectAuditor.Editor
             if (!caller.DebugInformation.HasSequencePoints)
                 return;
             
-            List<ProjectIssue> methodIssues = new List<ProjectIssue>();
+            CallTreeNode callerNode = new CallTreeNode(caller);
 
-            foreach (var inst in caller.Body.Instructions.Where(i =>
-                (i.OpCode == OpCodes.Call || i.OpCode == OpCodes.Callvirt || i.OpCode == OpCodes.Box)))
+            foreach (var inst in caller.Body.Instructions.Where(i => m_OpCoCodes.Contains(i.OpCode)))
             {
                 //var msg = string.Empty;
                 SequencePoint s = null;
@@ -156,88 +156,30 @@ namespace Unity.ProjectAuditor.Editor
                     }
                 }
 
-                ProblemDescriptor descriptor = null;
-                CallTreeNode calleeCallTreeNode = null;
-                CallTreeNode callerCallTreeNode = new CallTreeNode(caller);
-                Location location = callerCallTreeNode.location = new Location {path = s.Document.Url.Replace("\\", "/"), line = s.StartLine};
+                Location location = callerNode.location = new Location
+                    {path = s.Document.Url.Replace("\\", "/"), line = s.StartLine};
                 string description = String.Empty;
                     
                 if (inst.OpCode == OpCodes.Call || inst.OpCode == OpCodes.Callvirt)
                 {
-                    var callee = ((MethodReference) inst.Operand);
-
-                    callCrawler.Add(caller, callee, location);
-
-                    descriptor = m_ProblemDescriptors.SingleOrDefault(c => c.type == callee.DeclaringType.FullName &&
-                                                                           (c.method == callee.Name ||
-                                                                            ("get_" + c.method) == callee.Name));
-
-                    if (descriptor == null)
-                    {
-                        // Are we trying to warn about a whole namespace?
-                        descriptor = m_ProblemDescriptors.SingleOrDefault(c =>
-                            c.type == callee.DeclaringType.Namespace && c.method == "*");
-                    }
-
-                    // replace root with callee node
-                    calleeCallTreeNode = new CallTreeNode(callee, callerCallTreeNode);
-                    description = calleeCallTreeNode.prettyName;
+                    callCrawler.Add(caller, (MethodReference) inst.Operand, location);
                 }
-                else
+
+                foreach (var analyzer in m_InstructionAnalyzers)
                 {
-                    string opcode = inst.OpCode.Code.ToString();
-                    descriptor = m_ProblemsDefinedByOpCode.SingleOrDefault(p => p.opcode.Equals(opcode));
-                    if (descriptor == null)
+                    if (analyzer.GetOpCodes().Contains(inst.OpCode))
                     {
-                        continue;
+                        var projectIssue = analyzer.Analyze(inst);
+                        if (projectIssue != null)
+                        {
+                            projectIssue.callTree.AddChild(callerNode);
+                            projectIssue.location = location;
+                            projectIssue.assembly = a.Name.Name;
+
+                            projectReport.AddIssue(projectIssue);
+                        }                        
                     }
-                    var type = (TypeReference) inst.Operand;
-                    if (type.IsGenericParameter)
-                    {
-                        bool isValueType = true; // assume it's value type
-                        var genericType = (GenericParameter) type;
-                        if (genericType.HasReferenceTypeConstraint)
-                        {
-                            isValueType = false;
-                        }
-                        else
-                        {
-                            foreach (var constraint in genericType.Constraints)
-                            {
-                                if (!constraint.IsValueType)
-                                    isValueType = false;
-                            }                            
-                        }
-
-                        if (!isValueType)
-                        {
-                            // boxing on ref types are no-ops, so not a problem
-                            continue;                                
-                        }
-                    }
-
-                    description = string.Format("Conversion from value type '{0}' to ref type", type.Name);
-                    calleeCallTreeNode = new CallTreeNode(opcode, callerCallTreeNode);
-                }
-               
-                if (descriptor != null)
-                {
-                    if (string.IsNullOrEmpty(description))
-                        description = descriptor.description;
-
-                    var projectIssue = new ProjectIssue
-                    {
-                        description = description,
-                        category = IssueCategory.ApiCalls,
-                        descriptor = descriptor,
-                        callTree = calleeCallTreeNode,
-                        location = location,
-                        assembly = a.Name.Name
-                    };
-
-                    projectReport.AddIssue(projectIssue);
-                    methodIssues.Add(projectIssue);   
-                }
+                }               
             }
         }
 
@@ -252,11 +194,9 @@ namespace Unity.ProjectAuditor.Editor
 
                 foreach (var type in problemDescriptorTypes)
                 {
-                    Activator.CreateInstance(type, this);    
+                    AddAnalyzer(Activator.CreateInstance(type, this) as IInstructionAnalyzer);
                 }
             }
-
-            m_ProblemsDefinedByOpCode = m_ProblemDescriptors.Where(p => !string.IsNullOrEmpty(p.opcode)).ToArray();
         }
 
         static IEnumerable<Type> GetProblemDescriptorTypes(System.Reflection.Assembly assembly) {
@@ -265,6 +205,12 @@ namespace Unity.ProjectAuditor.Editor
                     yield return type;
                 }
             }
+        }
+
+        void AddAnalyzer(IInstructionAnalyzer analyzer)
+        {
+            m_InstructionAnalyzers.Add(analyzer);
+            m_OpCoCodes.AddRange(analyzer.GetOpCodes());
         }
         
         public void RegisterDescriptor(ProblemDescriptor descriptor)

--- a/Editor/ScriptAuditor.cs
+++ b/Editor/ScriptAuditor.cs
@@ -19,7 +19,7 @@ namespace Unity.ProjectAuditor.Editor
     {
         private List<IInstructionAnalyzer> m_InstructionAnalyzers = new List<IInstructionAnalyzer>();
         private List<ProblemDescriptor> m_ProblemDescriptors;
-        private List<OpCode> m_OpCoCodes = new List<OpCode>();
+        private List<OpCode> m_OpCodes = new List<OpCode>();
         
         private UnityEditor.Compilation.Assembly[] m_PlayerAssemblies;
 
@@ -142,7 +142,7 @@ namespace Unity.ProjectAuditor.Editor
             
             CallTreeNode callerNode = new CallTreeNode(caller);
 
-            foreach (var inst in caller.Body.Instructions.Where(i => m_OpCoCodes.Contains(i.OpCode)))
+            foreach (var inst in caller.Body.Instructions.Where(i => m_OpCodes.Contains(i.OpCode)))
             {
                 //var msg = string.Empty;
                 SequencePoint s = null;
@@ -210,7 +210,7 @@ namespace Unity.ProjectAuditor.Editor
         void AddAnalyzer(IInstructionAnalyzer analyzer)
         {
             m_InstructionAnalyzers.Add(analyzer);
-            m_OpCoCodes.AddRange(analyzer.GetOpCodes());
+            m_OpCodes.AddRange(analyzer.GetOpCodes());
         }
         
         public void RegisterDescriptor(ProblemDescriptor descriptor)

--- a/Tests/Editor/ProjectReportTest.cs
+++ b/Tests/Editor/ProjectReportTest.cs
@@ -67,6 +67,14 @@ namespace UnityEditor.ProjectAuditor.EditorTests
 			const string path = "ProjectAuditor_Report.csv";
 			projectReport.Export(path);
 			Assert.True(File.Exists(path));
+			
+			string line;
+			System.IO.StreamReader file = new System.IO.StreamReader(path);
+
+			line = file.ReadLine();
+			Assert.True(line.Equals("Issue,Area,Path,Line"));
+  
+			file.Close();  
 		}
 	}	
 }


### PR DESCRIPTION
- added IInstructionAnalyzer as Interface for specialized analyzers like BoxAnalyzer and CallAnalyzer
- added CallAnalyzer (default analyzer) which will check a specific function call against the predefined list of APIs 
- ScriptAuditor is now responsible for discovering (via Attribute) and instantiating each analyzer
- each analyzer is responsible for:
   - Registering its own problem descriptors, if applicable
   - Analysing a given instruction
   - Creating a ProjectIssue if needed.

