### PR TITLE
Disable package assemblies analysis by default.

### DIFF
--- a/Editor/ProjectAuditor.cs
+++ b/Editor/ProjectAuditor.cs
@@ -70,8 +70,8 @@ namespace Unity.ProjectAuditor.Editor
                 AssetDatabase.CreateAsset(m_ProjectAuditorConfig, assetPath);
             }
             
-            m_Auditors.Add(new ScriptAuditor());
-            m_Auditors.Add(new SettingsAuditor());
+            m_Auditors.Add(new ScriptAuditor(m_ProjectAuditorConfig));
+            m_Auditors.Add(new SettingsAuditor(m_ProjectAuditorConfig));
             // Add more Auditors here...
 
             LoadDatabase();

--- a/Editor/Script/ScriptAuditor.cs
+++ b/Editor/Script/ScriptAuditor.cs
@@ -5,7 +5,6 @@ using System.Linq;
 using Mono.Cecil;
 using Mono.Cecil.Cil;
 using Unity.ProjectAuditor.Editor.Utils;
-using UnityEditor;
 using UnityEditor.Compilation;
 using UnityEngine;
 using Assembly = System.Reflection.Assembly;
@@ -17,20 +16,16 @@ namespace Unity.ProjectAuditor.Editor
 {
     public class ScriptAuditor : IAuditor
     {
+        private ProjectAuditorConfig m_Config;
         private List<ProblemDescriptor> m_ProblemDescriptors;
         private string[] m_AssemblyNames;
 
         private readonly List<IInstructionAnalyzer> m_InstructionAnalyzers = new List<IInstructionAnalyzer>();
         private readonly List<OpCode> m_OpCodes = new List<OpCode>();
-        private readonly UnityEditor.Compilation.Assembly[] m_PlayerAssemblies;  
         
-        public ScriptAuditor()
+        internal ScriptAuditor(ProjectAuditorConfig config)
         {
-#if UNITY_2018_1_OR_NEWER
-            m_PlayerAssemblies = CompilationPipeline.GetAssemblies(AssembliesType.Player);
-#else
-            m_PlayerAssemblies = CompilationPipeline.GetAssemblies().Where(a => a.flags != AssemblyFlags.EditorAssembly).ToArray();
-#endif
+            m_Config = config;
         }
 
         public IEnumerable<ProblemDescriptor> GetDescriptors()
@@ -38,24 +33,9 @@ namespace Unity.ProjectAuditor.Editor
             return m_ProblemDescriptors;
         }
 
-        public IEnumerable<string> GetAssemblyNames()
+        public void Audit(ProjectReport projectReport, IProgressBar progressBar = null)
         {
-            if (m_AssemblyNames != null)
-                return m_AssemblyNames;
-
-            var names = new List<string>();
-            foreach (var assembly in m_PlayerAssemblies)
-            {
-                names.Add(assembly.name);
-            }
-
-            m_AssemblyNames = names.ToArray();
-            return m_AssemblyNames;
-        }
-
-        public void Audit( ProjectReport projectReport, IProgressBar progressBar = null)
-        {
-            if (!AssemblyHelper.CompileAssemblies())
+            if (!AssemblyHelper.CompileAssemblies(m_Config.enablePackages))
                 return;
 
             var callCrawler = new CallCrawler();                
@@ -80,9 +60,9 @@ namespace Unity.ProjectAuditor.Editor
                 }
                 
                 if (progressBar != null)
-                    progressBar.Initialize("Analyzing Scripts", "Analyzing project scripts", m_PlayerAssemblies.Length);
+                    progressBar.Initialize("Analyzing Scripts", "Analyzing project scripts", compiledAssemblyPaths.Count());
 
-                // Analyse all Player assemblies, including Package assemblies.
+                // Analyse all Player assemblies
                 foreach (var assemblyPath in compiledAssemblyPaths)
                 {
                     if (progressBar != null)

--- a/Editor/Settings/AnalyzerHelpers.cs
+++ b/Editor/Settings/AnalyzerHelpers.cs
@@ -51,14 +51,23 @@ namespace Unity.ProjectAuditor.Editor
 
         public bool PlayerSettingsManagedCodeStripping_iOS()
         {
+#if UNITY_2018_3_OR_NEWER
             var value = PlayerSettings.GetManagedStrippingLevel(BuildTargetGroup.iOS);
             return value == ManagedStrippingLevel.Disabled || value == ManagedStrippingLevel.Low;
+#else
+            return false;
+#endif
+
         }
 
         public bool PlayerSettingsManagedCodeStripping_Android()
         {
+#if UNITY_2018_3_OR_NEWER
             var value = PlayerSettings.GetManagedStrippingLevel(BuildTargetGroup.Android);
             return value == ManagedStrippingLevel.Disabled || value == ManagedStrippingLevel.Low;
+#else
+            return false;
+#endif        
         }
 
         public bool PhysicsLayerCollisionMatrix()

--- a/Editor/Settings/SettingsAuditor.cs
+++ b/Editor/Settings/SettingsAuditor.cs
@@ -9,14 +9,16 @@ namespace Unity.ProjectAuditor.Editor
 {
     public class SettingsAuditor : IAuditor
     {
+        private ProjectAuditorConfig m_Config;
         private List<ProblemDescriptor> m_ProblemDescriptors;
         
         private readonly System.Reflection.Assembly[] m_Assemblies;
         private readonly AnalyzerHelpers m_Helpers = new AnalyzerHelpers();
         private readonly List<KeyValuePair<string, string>> m_ProjectSettingsMapping = new List<KeyValuePair<string, string>>();
         
-        public SettingsAuditor()
+        internal SettingsAuditor(ProjectAuditorConfig config)
         {
+            m_Config = config;
             m_Assemblies = AppDomain.CurrentDomain.GetAssemblies();
             
             // UnityEditor

--- a/Editor/Utils/AssemblyHelper.cs
+++ b/Editor/Utils/AssemblyHelper.cs
@@ -46,7 +46,7 @@ namespace Unity.ProjectAuditor.Editor.Utils
 #else
             // fallback to CompilationPipeline assemblies 
             compiledAssemblyPaths = CompilationPipeline.GetAssemblies()
-                .Where(a => a.flags != AssemblyFlags.EditorAssembly).Select(assembly => assembly.outputPath);
+                .Where(a => a.flags != AssemblyFlags.EditorAssembly).Select(assembly => assembly.outputPath).ToArray();
 
             return true;
 #endif

--- a/Tests/Editor/ProjectReportTests.cs
+++ b/Tests/Editor/ProjectReportTests.cs
@@ -74,8 +74,8 @@ class MyClass
 				var line = file.ReadLine();
 				Assert.True(line.Equals("Issue,Message,Area,Path"));
 
-				var expectedLine =
-					$"{scriptIssue.descriptor.description},{scriptIssue.description},{scriptIssue.descriptor.area},{scriptIssue.relativePath}:{scriptIssue.line}"; 
+				var expectedLine = string.Format("{0},{1},{2},{3}:{4}", scriptIssue.descriptor.description, scriptIssue.description,
+					scriptIssue.descriptor.area, scriptIssue.relativePath, scriptIssue.line);
 				line = file.ReadLine();
 				Assert.True(line.Equals(expectedLine));
 			}			


### PR DESCRIPTION
Currently, the Script Auditor analyzes all generated assemblies, which can be very time-consuming on large projects. This PR disables package assemblies analysis by default.

Note that:
- The user can re-enable package assemblies analysis in the Project Auditor settings if needed, although it's probably something that only package authors will do.
- We can only detect whether an assembly belongs to a package as of 2019.x. For this reason, Project Auditor will still analyze packages in previous versions of Unity.