### PR TITLE
AssemblyCompilation exception

### DIFF
--- a/Editor/Script/ScriptAuditor.cs
+++ b/Editor/Script/ScriptAuditor.cs
@@ -35,14 +35,12 @@ namespace Unity.ProjectAuditor.Editor
 
         public void Audit(ProjectReport projectReport, IProgressBar progressBar = null)
         {
-            if (!AssemblyHelper.CompileAssemblies())
-                return;
-
             var callCrawler = new CallCrawler();                
 
+            using (var compilationHelper = new AssemblyCompilationHelper())
             using (var assemblyResolver = new DefaultAssemblyResolver())
             {
-                var compiledAssemblyPaths = AssemblyHelper.GetCompiledAssemblyPaths();
+                var compiledAssemblyPaths = compilationHelper.Compile();
   
                 foreach (var dir in AssemblyHelper.GetPrecompiledAssemblyDirectories())
                 {
@@ -54,7 +52,7 @@ namespace Unity.ProjectAuditor.Editor
                     assemblyResolver.AddSearchDirectory(dir);    
                 }
 
-                foreach (var dir in AssemblyHelper.GetCompiledAssemblyDirectories())
+                foreach (var dir in compilationHelper.GetCompiledAssemblyDirectories())
                 {
                     assemblyResolver.AddSearchDirectory(dir);    
                 }

--- a/Editor/UI/ProjectAuditorWindow.cs
+++ b/Editor/UI/ProjectAuditorWindow.cs
@@ -245,13 +245,21 @@ In addition, it is possible to filter issues by area (CPU/Memory/etc...) or asse
 
         private void Analyze()
         {
-            m_ProjectReport = m_ProjectAuditor.Audit(new ProgressBarDisplay());
+            try
+            {
+                m_ProjectReport = m_ProjectAuditor.Audit(new ProgressBarDisplay());
 
-            // update list of assembly names
-            m_AssemblyNames = Utils.AssemblyHelper.GetCompiledAssemblyNames().ToArray();
-            UpdateAssemblySelection();
+                // update list of assembly names
+                var scriptIssues = m_ProjectReport.GetIssues(IssueCategory.ApiCalls);
+                m_AssemblyNames = scriptIssues.Select(i => i.assembly).Distinct().OrderBy(str => str).ToArray();
+                UpdateAssemblySelection();
 
-            m_ValidReport = true;
+                m_ValidReport = true;
+            }
+            catch (AssemblyCompilationException e)
+            {
+                Debug.LogError(e);
+            }
             
             m_IssueTables.Clear();
             

--- a/Editor/UI/ProjectAuditorWindow.cs
+++ b/Editor/UI/ProjectAuditorWindow.cs
@@ -259,6 +259,7 @@ In addition, it is possible to filter issues by area (CPU/Memory/etc...) or asse
             catch (AssemblyCompilationException e)
             {
                 Debug.LogError(e);
+                m_ValidReport = false;
             }
             
             m_IssueTables.Clear();

--- a/Editor/Utils/AssemblyCompilationException.cs
+++ b/Editor/Utils/AssemblyCompilationException.cs
@@ -1,0 +1,9 @@
+using System;
+
+namespace Unity.ProjectAuditor.Editor
+{
+    public class AssemblyCompilationException : Exception
+    {
+        
+    }
+}

--- a/Editor/Utils/AssemblyCompilationException.cs.meta
+++ b/Editor/Utils/AssemblyCompilationException.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 9581c04d692648b48f73fb2525f7ee04
+timeCreated: 1581693913

--- a/Editor/Utils/AssemblyCompilationHelper.cs
+++ b/Editor/Utils/AssemblyCompilationHelper.cs
@@ -15,10 +15,10 @@ namespace Unity.ProjectAuditor.Editor.Utils
 
         public IEnumerable<string> Compile()
         {
+            if (EditorUtility.scriptCompilationFailed)
+                throw new AssemblyCompilationException();
 #if UNITY_2018_2_OR_NEWER
             m_OutputFolder = FileUtil.GetUniqueTempPathInProject();
-            if (Directory.Exists(m_OutputFolder))
-                Directory.Delete(m_OutputFolder, true);
             
             CompilationPipeline.assemblyCompilationFinished += OnAssemblyCompilationFinished;
             
@@ -32,7 +32,7 @@ namespace Unity.ProjectAuditor.Editor.Utils
 
             if (!m_Success)
                 throw new AssemblyCompilationException();
-                
+
             return compilationResult.assemblies.Select(assembly => Path.Combine(m_OutputFolder, assembly));
 #else
             // fallback to CompilationPipeline assemblies 

--- a/Editor/Utils/AssemblyCompilationHelper.cs
+++ b/Editor/Utils/AssemblyCompilationHelper.cs
@@ -1,0 +1,70 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using UnityEditor;
+using UnityEditor.Build.Player;
+using UnityEditor.Compilation;
+
+namespace Unity.ProjectAuditor.Editor.Utils
+{
+    public class AssemblyCompilationHelper : IDisposable
+    {
+        private bool m_Success = true;
+        private string m_OutputFolder = null;
+
+        public IEnumerable<string> Compile()
+        {
+#if UNITY_2018_2_OR_NEWER
+            m_OutputFolder = FileUtil.GetUniqueTempPathInProject();
+            if (Directory.Exists(m_OutputFolder))
+                Directory.Delete(m_OutputFolder, true);
+            
+            CompilationPipeline.assemblyCompilationFinished += OnAssemblyCompilationFinished;
+            
+            var input = new ScriptCompilationSettings
+            {
+                target = EditorUserBuildSettings.activeBuildTarget,
+                @group = EditorUserBuildSettings.selectedBuildTargetGroup
+            };
+
+            var compilationResult = PlayerBuildInterface.CompilePlayerScripts(input, m_OutputFolder);
+
+            if (!m_Success)
+                throw new AssemblyCompilationException();
+                
+            return compilationResult.assemblies.Select(assembly => Path.Combine(m_OutputFolder, assembly));
+#else
+            // fallback to CompilationPipeline assemblies 
+            return CompilationPipeline.GetAssemblies()
+                .Where(a => a.flags != AssemblyFlags.EditorAssembly).Select(assembly => assembly.outputPath);
+#endif
+        }
+        
+        public void Dispose()
+        {
+#if UNITY_2018_2_OR_NEWER
+            CompilationPipeline.assemblyCompilationFinished -= OnAssemblyCompilationFinished;
+#endif
+            if (!string.IsNullOrEmpty(m_OutputFolder))
+            {
+                Directory.Delete(m_OutputFolder, true);
+            }
+        }
+        
+        public IEnumerable<string> GetCompiledAssemblyDirectories()
+        {
+#if UNITY_2018_2_OR_NEWER
+            yield return m_OutputFolder;
+#else
+            yield return CompilationPipeline.GetAssemblies()
+                .Where(a => a.flags != AssemblyFlags.EditorAssembly).Select(assembly => assembly.outputPath)
+#endif
+        }
+
+        private void OnAssemblyCompilationFinished(string outputAssemblyPath, CompilerMessage[] messages)
+        {
+            m_Success = m_Success && messages.Count(message => message.type == CompilerMessageType.Error) == 0;
+        }
+    }
+}

--- a/Editor/Utils/AssemblyCompilationHelper.cs.meta
+++ b/Editor/Utils/AssemblyCompilationHelper.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: c517a669ce5046e0bbf288b12ead7f67
+timeCreated: 1581935143

--- a/Editor/Utils/AssemblyHelper.cs
+++ b/Editor/Utils/AssemblyHelper.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;

--- a/Editor/Utils/AssemblyHelper.cs
+++ b/Editor/Utils/AssemblyHelper.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -6,7 +5,8 @@ using UnityEditor;
 using UnityEditor.Compilation;
 
 #if UNITY_2018_2_OR_NEWER
-using UnityEditor.Build.Player;
+using UnityEngine;
+
 #endif
 
 #if UNITY_2019_3_OR_NEWER
@@ -17,8 +17,6 @@ namespace Unity.ProjectAuditor.Editor.Utils
 {
     public static class AssemblyHelper
     {
-        private static string[] compiledAssemblyPaths = new string[]{};
-
         public static string DefaultAssemblyFileName = "Assembly-CSharp.dll";
         
         public static string DefaultAssemblyName
@@ -27,56 +25,6 @@ namespace Unity.ProjectAuditor.Editor.Utils
             {
                 return Path.GetFileNameWithoutExtension(DefaultAssemblyFileName);
             }
-        }
-        
-        public static bool CompileAssemblies()
-        {
-#if UNITY_2018_2_OR_NEWER
-            var path = compiledAssemblyPaths.FirstOrDefault();
-            if (!string.IsNullOrEmpty(path))
-            {
-                Directory.Delete(Path.GetDirectoryName(path), true);
-            }
-
-            var outputFolder = FileUtil.GetUniqueTempPathInProject();
-            if (Directory.Exists(outputFolder))
-                Directory.Delete(outputFolder, true);
-
-            var input = new ScriptCompilationSettings
-            {
-                target = EditorUserBuildSettings.activeBuildTarget,
-                @group = EditorUserBuildSettings.selectedBuildTargetGroup
-            };
-
-            var compilationResult = PlayerBuildInterface.CompilePlayerScripts(input, outputFolder);
-
-            compiledAssemblyPaths =
-                compilationResult.assemblies.Select(assembly => Path.Combine(outputFolder, assembly)).ToArray();
-
-            return compilationResult.assemblies.Count > 0;
-#else
-            // fallback to CompilationPipeline assemblies 
-            compiledAssemblyPaths = CompilationPipeline.GetAssemblies()
-                .Where(a => a.flags != AssemblyFlags.EditorAssembly).Select(assembly => assembly.outputPath).ToArray();
-
-            return true;
-#endif
-        }
-        public static IEnumerable<string> GetCompiledAssemblyPaths()
-        {
-            return compiledAssemblyPaths;  
-        }
-
-        public static IEnumerable<string> GetCompiledAssemblyNames()
-        {
-            var list = compiledAssemblyPaths.Select(assemblyPath => Path.GetFileNameWithoutExtension(assemblyPath)).ToList();
-            list.Sort();            
-            return list.ToArray();
-        }
-
-        public static IEnumerable<string> GetCompiledAssemblyDirectories()
-        {
-            return GetCompiledAssemblyPaths().Select(path => Path.GetDirectoryName(path)).Distinct();
         }
 
         public static IEnumerable<string> GetPrecompiledAssemblyPaths()

--- a/Tests/Editor/AssemblyCompilationExceptionTests.cs
+++ b/Tests/Editor/AssemblyCompilationExceptionTests.cs
@@ -30,6 +30,7 @@ class MyClass {
         }
         
         [Test]
+        [ExplicitAttribute]
         public void ExceptionIsThrownOnCompilationError()
         {
             LogAssert.ignoreFailingMessages = true;

--- a/Tests/Editor/AssemblyCompilationExceptionTests.cs
+++ b/Tests/Editor/AssemblyCompilationExceptionTests.cs
@@ -1,6 +1,9 @@
+using System;
 using NUnit.Framework;
 using Unity.ProjectAuditor.Editor;
 using Unity.ProjectAuditor.Editor.Utils;
+using UnityEngine;
+using UnityEngine.TestTools;
 
 namespace UnityEditor.ProjectAuditor.EditorTests
 {
@@ -29,6 +32,8 @@ class MyClass {
         [Test]
         public void ExceptionIsThrownOnCompilationError()
         {
+            LogAssert.ignoreFailingMessages = true;
+
             var exceptionThrown = false;
             try
             {
@@ -37,10 +42,10 @@ class MyClass {
                     compilationHelper.Compile();
                 }
             }
-            catch (AssemblyCompilationException)
             {
                 exceptionThrown = true;
             }
+            LogAssert.ignoreFailingMessages = false;
             
             Assert.True(exceptionThrown);
         }

--- a/Tests/Editor/AssemblyCompilationExceptionTests.cs
+++ b/Tests/Editor/AssemblyCompilationExceptionTests.cs
@@ -46,9 +46,12 @@ class MyClass {
             {
                 exceptionThrown = true;
             }
-            LogAssert.ignoreFailingMessages = false;
             
             Assert.True(exceptionThrown);
+            
+            LogAssert.Expect(LogType.Error, "Assets/ProjectAuditor-Temp/MyClass.cs(6,1): error CS1519: Invalid token '}' in class, struct, or interface member declaration");
+            LogAssert.Expect(LogType.Error, "Failed to compile player scripts");
+            LogAssert.ignoreFailingMessages = false;
         }
     }
 }

--- a/Tests/Editor/AssemblyCompilationExceptionTests.cs
+++ b/Tests/Editor/AssemblyCompilationExceptionTests.cs
@@ -42,6 +42,7 @@ class MyClass {
                     compilationHelper.Compile();
                 }
             }
+            catch (AssemblyCompilationException)
             {
                 exceptionThrown = true;
             }

--- a/Tests/Editor/AssemblyCompilationExceptionTests.cs
+++ b/Tests/Editor/AssemblyCompilationExceptionTests.cs
@@ -1,0 +1,48 @@
+using NUnit.Framework;
+using Unity.ProjectAuditor.Editor;
+using Unity.ProjectAuditor.Editor.Utils;
+
+namespace UnityEditor.ProjectAuditor.EditorTests
+{
+    public class AssemblyCompilationExceptionTests
+    {
+        private ScriptResource m_ScriptResource;
+
+        [OneTimeSetUp]
+        public void SetUp()
+        {
+            m_ScriptResource = new ScriptResource("MyClass.cs", @"
+class MyClass {
+#if !UNITY_EDITOR
+    asd
+#endif
+}
+");
+        }
+
+        [OneTimeTearDown]
+        public void TearDown()
+        {
+            m_ScriptResource.Delete();
+        }
+        
+        [Test]
+        public void ExceptionIsThrownOnCompilationError()
+        {
+            var exceptionThrown = false;
+            try
+            {
+                using (var compilationHelper = new AssemblyCompilationHelper())
+                {
+                    compilationHelper.Compile();
+                }
+            }
+            catch (AssemblyCompilationException)
+            {
+                exceptionThrown = true;
+            }
+            
+            Assert.True(exceptionThrown);
+        }
+    }
+}

--- a/Tests/Editor/AssemblyCompilationExceptionTests.cs.meta
+++ b/Tests/Editor/AssemblyCompilationExceptionTests.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: fd0baa8addeb4fae9b74164fb33d68c9
+timeCreated: 1581957293

--- a/Tests/Editor/AssemblyHelperTests.cs
+++ b/Tests/Editor/AssemblyHelperTests.cs
@@ -24,11 +24,13 @@ namespace UnityEditor.ProjectAuditor.EditorTests
         [Test]
         public void DefaultAssemblyPathIsFound()
         {
-            AssemblyHelper.CompileAssemblies();
-            var paths = AssemblyHelper.GetCompiledAssemblyPaths();
-
-            Assert.Positive(paths.Count());
-            Assert.NotNull(paths.FirstOrDefault(path => path.Contains(AssemblyHelper.DefaultAssemblyFileName)));
+            using (var compilationHelper = new AssemblyCompilationHelper())
+            {
+                var paths = compilationHelper.Compile();
+                
+                Assert.Positive(paths.Count());
+                Assert.NotNull(paths.FirstOrDefault(path => path.Contains(AssemblyHelper.DefaultAssemblyFileName)));
+            }
         }
         
         [Test]


### PR DESCRIPTION
At the moment, a script compilation error causes the Project Auditor UI to be in unclear state: no code issues reported with no message to the user.

This PR adds AssemblyCompilationException which will be thrown by ProjectAuditor upon script compilation error. ProjectAuditorWindow is responsible for catching this exception, which will log an error in the console.

In addition, the list of assemblies in the UI is now populated based on the reported issues, as opposed to all generated assemblies. By doing this, the UI will not list any assembly which does not contain any issue.
