### PR TITLE
Add Object.Instantiate and GameObject.AddComponent support

### DIFF
--- a/Data/ApiDatabase.json
+++ b/Data/ApiDatabase.json
@@ -2239,6 +2239,26 @@
             "area": "Memory",
             "problem": "The GameObject.tag property allocates managed memory.",
             "solution": "Try to avoid getting this property in frequently-updated code. Prefer using GameObject.CompareTag() instead, as this does not result in managed allocations."
+        },
+        {
+            "id": 101224,
+            "type": "UnityEngine.Object",
+            "method": "Instantiate",
+            "value": "",
+            "customevaluator": "",
+            "area": "CPU",
+            "problem": "Instantiationg Objects at runtime can be a very expensive operation.",
+            "solution": "Try to avoid calling Object.Instantiate frequently-updated code."
+        },
+        {
+            "id": 101225,
+            "type": "UnityEngine.GameObject",
+            "method": "AddComponent",
+            "value": "",
+            "customevaluator": "",
+            "area": "CPU",
+            "problem": "Adding components to GameObjects at runtime can be a very expensive operation.",
+            "solution": "Try to avoid getting this property in frequently-updated code. Prefer instantiating GameObjects from Prefabs will all the necessary components instead."
         }
     ]
 }

--- a/Tests/Editor/InstantiateAddComponentTests.cs
+++ b/Tests/Editor/InstantiateAddComponentTests.cs
@@ -1,0 +1,67 @@
+using System.Linq;
+using NUnit.Framework;
+
+namespace UnityEditor.ProjectAuditor.EditorTests
+{
+    public class InstantiateAddComponentTests
+    {
+        private ScriptResource m_ScriptResourceInstantiate;
+        private ScriptResource m_ScriptResourceAddComponent;
+        
+        [OneTimeSetUp]
+        public void SetUp()
+        {
+             m_ScriptResourceInstantiate = new ScriptResource("InstantiateObject.cs", @"
+using UnityEngine;
+class InstantiateObject : MonoBehaviour
+{
+	void Start()
+	{
+        var obj = GameObject.CreatePrimitive(PrimitiveType.Cube);
+        Instantiate(obj);
+	}
+}
+");
+
+             m_ScriptResourceAddComponent = new ScriptResource("AddComponentToGameObject.cs", @"
+using UnityEngine;
+class AddComponentToGameObject : MonoBehaviour
+{
+	void Start()
+	{
+        var obj = GameObject.CreatePrimitive(PrimitiveType.Cube);
+        var instance = Instantiate(obj) as GameObject;
+		instance.AddComponent<Rigidbody>();
+	}
+}
+");
+        }
+
+        [OneTimeTearDown]
+        public void TearDown()
+        {
+	        m_ScriptResourceInstantiate.Delete();
+	        m_ScriptResourceAddComponent.Delete();
+        }
+        
+        [Test]
+        public void InstantiateIssueIsFound()
+        {
+            var issues = ScriptIssueTestHelper.AnalyzeAndFindScriptIssues(m_ScriptResourceInstantiate);
+			
+            Assert.AreEqual(1, issues.Count());
+						
+            Assert.True(issues.First().callingMethod.Equals("System.Void InstantiateObject::Start()"));
+        }
+		
+        [Test]
+        public void AddComponentIssueIsFound()
+        {
+            var issues = ScriptIssueTestHelper.AnalyzeAndFindScriptIssues(m_ScriptResourceAddComponent);
+			
+            Assert.AreEqual(1, issues.Count());
+						
+            Assert.True(issues.First().callingMethod.Equals("System.Void AddComponentToGameObject::Start()"));
+        }
+    }
+}

--- a/Tests/Editor/InstantiateAddComponentTests.cs
+++ b/Tests/Editor/InstantiateAddComponentTests.cs
@@ -15,10 +15,11 @@ namespace UnityEditor.ProjectAuditor.EditorTests
 using UnityEngine;
 class InstantiateObject : MonoBehaviour
 {
+	public GameObject Prefab;
+	public GameObject Instance;
 	void Start()
 	{
-        var obj = GameObject.CreatePrimitive(PrimitiveType.Cube);
-        Instantiate(obj);
+        Instance = Instantiate(Prefab);
 	}
 }
 ");
@@ -27,11 +28,10 @@ class InstantiateObject : MonoBehaviour
 using UnityEngine;
 class AddComponentToGameObject : MonoBehaviour
 {
+	public GameObject Instance;
 	void Start()
 	{
-        var obj = GameObject.CreatePrimitive(PrimitiveType.Cube);
-        var instance = Instantiate(obj) as GameObject;
-		instance.AddComponent<Rigidbody>();
+		Instance.AddComponent<Rigidbody>();
 	}
 }
 ");

--- a/Tests/Editor/InstantiateAddComponentTests.cs.meta
+++ b/Tests/Editor/InstantiateAddComponentTests.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: cbc5412790e4454da250f5db6d181e56
+timeCreated: 1582717735


### PR DESCRIPTION
Object.Instantiate and GameObject.AddComponent calls can have an impact on performance.

This PR introduces support for detecting them.

Note that the spreadsheet containing all issues will need to be updated.