### PR TITLE
Add String.Concat support

### DIFF
--- a/Data/ApiDatabase.json
+++ b/Data/ApiDatabase.json
@@ -2239,6 +2239,16 @@
             "area": "Memory",
             "problem": "The GameObject.tag property allocates managed memory.",
             "solution": "Try to avoid getting this property in frequently-updated code. Prefer using GameObject.CompareTag() instead, as this does not result in managed allocations."
+        },
+        {
+            "id": 101226,
+            "type": "System.String",
+            "method": "Concat",
+            "value": "",
+            "customevaluator": "",
+            "area": "Memory",
+            "problem": "String concatenation operations allocates managed memory",
+            "solution": "Try to avoid concatenating strings in frequently-updated code. Prefer using a StringBuilder instead, as this minimizes managed allocations."
         }
     ]
 }

--- a/Tests/Editor/BoxingIssueTests.cs
+++ b/Tests/Editor/BoxingIssueTests.cs
@@ -17,10 +17,10 @@ namespace UnityEditor.ProjectAuditor.EditorTests
 		[OneTimeSetUp]
 		public void SetUp()
 		{
-			m_ScriptResourceBoxingInt = new ScriptResource("BoxingIntTest.cs", "using UnityEngine; class BoxingIntTest : MonoBehaviour { void Start() { Debug.Log(\"The number of the beast is: \" + 666); } }");
-			m_ScriptResourceBoxingFloat = new ScriptResource("BoxingFloatTest.cs", "using UnityEngine; class BoxingFloatTest : MonoBehaviour { void Start() { Debug.Log(\"The number of the beast is: \" + 666.0f); } }");
-			m_ScriptResourceBoxingGenericRefType = new ScriptResource("BoxingGenericRefType.cs", "using UnityEngine; class SomeClass {}; class BoxingGenericRefType<T> where T : SomeClass { T refToGenericType; void Start() { if (refToGenericType == null){} } }");
-			m_ScriptResourceBoxingGeneric = new ScriptResource("BoxingGeneric.cs", "using UnityEngine; class BoxingGeneric<T> { T refToGenericType; void Start() { if (refToGenericType == null){} } }");
+			m_ScriptResourceBoxingInt = new ScriptResource("BoxingIntTest.cs", "using System; class BoxingIntTest { Object Dummy() { return 666; } }");
+			m_ScriptResourceBoxingFloat = new ScriptResource("BoxingFloatTest.cs", "using System; class BoxingFloatTest { Object Dummy() { return 666.0f; } }");
+			m_ScriptResourceBoxingGenericRefType = new ScriptResource("BoxingGenericRefType.cs", "class SomeClass {}; class BoxingGenericRefType<T> where T : SomeClass { T refToGenericType; void Dummy() { if (refToGenericType == null){} } }");
+			m_ScriptResourceBoxingGeneric = new ScriptResource("BoxingGeneric.cs", "class BoxingGeneric<T> { T refToGenericType; void Dummy() { if (refToGenericType == null){} } }");
 		}
 
 		[OneTimeTearDown]
@@ -43,10 +43,10 @@ namespace UnityEditor.ProjectAuditor.EditorTests
 
 			// check issue
 			Assert.NotNull(boxingInt);
-			Assert.True(boxingInt.name.Equals("BoxingIntTest.Start"));
+			Assert.True(boxingInt.name.Equals("BoxingIntTest.Dummy"));
 			Assert.True(boxingInt.filename.Equals(m_ScriptResourceBoxingInt.scriptName));
 			Assert.True(boxingInt.description.Equals("Conversion from value type 'Int32' to ref type"));
-			Assert.True(boxingInt.callingMethod.Equals("System.Void BoxingIntTest::Start()"));
+			Assert.True(boxingInt.callingMethod.Equals("System.Object BoxingIntTest::Dummy()"));
 			Assert.AreEqual(1, boxingInt.line);
 			Assert.AreEqual(IssueCategory.ApiCalls, boxingInt.category);
 
@@ -72,10 +72,10 @@ namespace UnityEditor.ProjectAuditor.EditorTests
 
 			// check issue
 			Assert.NotNull(boxingFloat);
-			Assert.True(boxingFloat.name.Equals("BoxingFloatTest.Start"));
+			Assert.True(boxingFloat.name.Equals("BoxingFloatTest.Dummy"));
 			Assert.True(boxingFloat.filename.Equals(m_ScriptResourceBoxingFloat.scriptName));
 			Assert.True(boxingFloat.description.Equals("Conversion from value type 'float' to ref type"));
-			Assert.True(boxingFloat.callingMethod.Equals("System.Void BoxingFloatTest::Start()"));
+			Assert.True(boxingFloat.callingMethod.Equals("System.Object BoxingFloatTest::Dummy()"));
 			Assert.AreEqual(1, boxingFloat.line);
 			Assert.AreEqual(IssueCategory.ApiCalls, boxingFloat.category);
 			

--- a/Tests/Editor/StringConcatTests.cs
+++ b/Tests/Editor/StringConcatTests.cs
@@ -1,0 +1,41 @@
+using System.Linq;
+using NUnit.Framework;
+
+namespace UnityEditor.ProjectAuditor.EditorTests
+{
+    public class StringConcatTests
+    {
+        private ScriptResource m_ScriptResourceStringConcat;
+        
+        [OneTimeSetUp]
+        public void SetUp()
+        {
+	        m_ScriptResourceStringConcat = new ScriptResource("StringConcat.cs", @"
+class StringConcat
+{
+	string text;
+	string Dummy()
+	{
+		return text + text;
+    }
+}
+");
+        }
+
+        [OneTimeTearDown]
+        public void TearDown()
+        {
+            m_ScriptResourceStringConcat.Delete();
+        }
+        
+        [Test]
+        public void StringConcatIssueIsFound()
+        {
+            var issues = ScriptIssueTestHelper.AnalyzeAndFindScriptIssues(m_ScriptResourceStringConcat);
+			
+            Assert.AreEqual(1, issues.Count());
+						
+            Assert.True(issues.First().description.Equals("System.String.Concat"));
+        }
+    }
+}

--- a/Tests/Editor/StringConcatTests.cs.meta
+++ b/Tests/Editor/StringConcatTests.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: f4e66cb3ece54bffa3a0739d344f174b
+timeCreated: 1582719437


### PR DESCRIPTION
Concatenating strings can have an impact on memory, and possibly to CPU performance due to garbage collection, since it requires allocating a new string object.

This PR introduces support for detecting string concatenations.

Note that the spreadsheet containing all issues will need to be updated.