### PR TITLE
ComponentSystem/JobComponentSystem.OnUpdate are perf critical contexts

### DIFF
--- a/Editor/Auditors/ScriptAuditor.cs
+++ b/Editor/Auditors/ScriptAuditor.cs
@@ -180,8 +180,13 @@ namespace Unity.ProjectAuditor.Editor.Auditors
 
         private static bool IsPerformanceCriticalContext(MethodDefinition methodDefinition)
         {
-            return MonoBehaviourAnalysis.IsMonoBehaviour(methodDefinition.DeclaringType) &&
-                   MonoBehaviourAnalysis.IsMonoBehaviourUpdateMethod(methodDefinition);
+            if (MonoBehaviourAnalysis.IsMonoBehaviour(methodDefinition.DeclaringType) &&
+                MonoBehaviourAnalysis.IsMonoBehaviourUpdateMethod(methodDefinition))
+                return true;
+            if (ComponentSystemAnalysis.IsComponentSystem(methodDefinition.DeclaringType) &&
+                ComponentSystemAnalysis.IsOnUpdateMethod(methodDefinition))
+                return true;
+            return false;
         }
     }
 }

--- a/Editor/CodeAnalysis/ComponentSystemAnalysis.cs
+++ b/Editor/CodeAnalysis/ComponentSystemAnalysis.cs
@@ -1,0 +1,42 @@
+using System;
+using System.Linq;
+using Mono.Cecil;
+using UnityEngine;
+
+namespace Unity.ProjectAuditor.Editor.CodeAnalysis
+{
+    internal static class ComponentSystemAnalysis
+    {
+        private static readonly int[] ClassNameHashCodes = {"Unity.Entities.ComponentSystem".GetHashCode(), "Unity.Entities.JobComponentSystem".GetHashCode()};
+
+        private static readonly string[] UpdateMethodNames = {"OnUpdate"};
+
+        public static bool IsComponentSystem(TypeReference typeReference)
+        {
+            TypeDefinition typeDefinition = null;
+            try
+            {
+                typeDefinition = typeReference.Resolve();
+            }
+            catch (AssemblyResolutionException e)
+            {
+                Debug.LogWarning(e);
+                return false;
+            }
+
+            if (ClassNameHashCodes.FirstOrDefault(i => i == typeDefinition.FullName.GetHashCode()) != null &&
+                typeDefinition.Module.Name.Equals("Unity.Entities.dll"))
+                return true;
+
+            if (typeDefinition.BaseType != null)
+                return IsComponentSystem(typeDefinition.BaseType);
+
+            return false;
+        }
+
+        public static bool IsOnUpdateMethod(MethodDefinition methodDefinition)
+        {
+            return UpdateMethodNames.Contains(methodDefinition.Name);
+        }
+    }
+}

--- a/Editor/CodeAnalysis/ComponentSystemAnalysis.cs.meta
+++ b/Editor/CodeAnalysis/ComponentSystemAnalysis.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 6b16c7eac5cc4feaab9042de66843500
+timeCreated: 1583522149


### PR DESCRIPTION
With this PR, Project Auditor will be able to identify whether issues are found inside Unity.Entities.ComponentSystem/JobComponentSystem.OnUpdate and highlight them to the user as Performance critical contexts.

Since we do the same for MonoBehaviour.FixedUpdate/UpdateLateUpdate, once this lands the code will be generalized.