### PR TITLE
add assembly compilation progress bar

### DIFF
--- a/Editor/Auditors/ScriptAuditor.cs
+++ b/Editor/Auditors/ScriptAuditor.cs
@@ -36,7 +36,7 @@ namespace Unity.ProjectAuditor.Editor.Auditors
             using (var compilationHelper = new AssemblyCompilationHelper())
             using (var assemblyResolver = new DefaultAssemblyResolver())
             {
-                var compiledAssemblyPaths = compilationHelper.Compile();
+                var compiledAssemblyPaths = compilationHelper.Compile(progressBar);
 
                 foreach (var dir in AssemblyHelper.GetPrecompiledAssemblyDirectories())
                     assemblyResolver.AddSearchDirectory(dir);


### PR DESCRIPTION
At the moment the progress bar does not show us during assembly compilation, which occurs before the actual analysis. This PR fixes this problem.