### PR TITLE
Add displayOnlyCrititalIssues option

### DIFF
--- a/Editor/ProjectAuditorConfig.cs
+++ b/Editor/ProjectAuditorConfig.cs
@@ -6,6 +6,7 @@ namespace Unity.ProjectAuditor.Editor
 {
     public class ProjectAuditorConfig : ScriptableObject
     {
+        public bool displayOnlyCrititalIssues;
         public bool displayMutedIssues;
         public bool enableAnalyzeOnBuild;
         public bool enableFailBuildOnIssues;

--- a/Editor/UI/AnalysisView.cs
+++ b/Editor/UI/AnalysisView.cs
@@ -12,6 +12,7 @@ namespace Unity.ProjectAuditor.Editor
         public string name;
         public bool groupByDescription;
         public bool showAssemblySelection;
+        public bool showCritical;
         public bool showInvertedCallTree;
         public bool showFilenameColumn;
         public bool showAssemblyColumn;
@@ -57,8 +58,11 @@ namespace Unity.ProjectAuditor.Editor
                         minWidth = 100;
                         break;
                     case IssueTable.Column.Priority:
-                        width = 22;
-                        minWidth = 22;
+                        if (m_Desc.showCritical)
+                        {
+                            width = 22;
+                            minWidth = 22;
+                        }
                         break;
                     case IssueTable.Column.Area:
                         width = 60;

--- a/Editor/UI/ProjectAuditorWindow.cs
+++ b/Editor/UI/ProjectAuditorWindow.cs
@@ -36,6 +36,7 @@ namespace Unity.ProjectAuditor.Editor
                 name = IssueCategory.ApiCalls.ToString(),
                 groupByDescription = true,
                 showAssemblySelection = true,
+                showCritical = true,
                 showInvertedCallTree = true,
                 showFilenameColumn = true,
                 showAssemblyColumn = true
@@ -46,6 +47,7 @@ namespace Unity.ProjectAuditor.Editor
                 name = IssueCategory.ProjectSettings.ToString(),
                 groupByDescription = false,
                 showAssemblySelection = false,
+                showCritical = false,
                 showInvertedCallTree = false,
                 showFilenameColumn = false,
                 showAssemblyColumn = false
@@ -107,9 +109,10 @@ namespace Unity.ProjectAuditor.Editor
                 if (m_ProjectAuditor.config.GetAction(issue.descriptor, issue.callingMethod) == Rule.Action.None)
                     return false;
 
-            if (m_ProjectAuditor.config.displayOnlyCrititalIssues)
-                if (!issue.isPerfCriticalContext)
-                    return false;
+            if (m_ActiveAnalysisView.desc.showCritical &&
+                m_ProjectAuditor.config.displayOnlyCrititalIssues &&
+                !issue.isPerfCriticalContext)
+                return false;
 
             if (!string.IsNullOrEmpty(m_SearchText))
                 if (!MatchesSearch(issue.description) &&
@@ -646,8 +649,12 @@ namespace Unity.ProjectAuditor.Editor
                 
                 EditorGUILayout.BeginHorizontal();
                 EditorGUILayout.LabelField("Show :", GUILayout.ExpandWidth(true), GUILayout.Width(80));
+
+                GUI.enabled = m_ActiveAnalysisView.desc.showCritical;
                 m_ProjectAuditor.config.displayOnlyCrititalIssues = EditorGUILayout.ToggleLeft("Only Critical Issues",
                     m_ProjectAuditor.config.displayOnlyCrititalIssues, GUILayout.Width(160));
+                GUI.enabled = true; 
+
                 m_ProjectAuditor.config.displayMutedIssues = EditorGUILayout.ToggleLeft("Muted Issues",
                     m_ProjectAuditor.config.displayMutedIssues, GUILayout.Width(127));
                 EditorGUILayout.EndHorizontal();

--- a/Editor/UI/ProjectAuditorWindow.cs
+++ b/Editor/UI/ProjectAuditorWindow.cs
@@ -107,6 +107,10 @@ namespace Unity.ProjectAuditor.Editor
                 if (m_ProjectAuditor.config.GetAction(issue.descriptor, issue.callingMethod) == Rule.Action.None)
                     return false;
 
+            if (m_ProjectAuditor.config.displayOnlyCrititalIssues)
+                if (!issue.isPerfCriticalContext)
+                    return false;
+
             if (!string.IsNullOrEmpty(m_SearchText))
                 if (!MatchesSearch(issue.description) &&
                     !MatchesSearch(issue.filename) &&
@@ -624,8 +628,6 @@ namespace Unity.ProjectAuditor.Editor
 
                 EditorGUILayout.BeginHorizontal();
                 EditorGUILayout.LabelField("Selected :", GUILayout.ExpandWidth(true), GUILayout.Width(80));
-                m_ProjectAuditor.config.displayMutedIssues = EditorGUILayout.ToggleLeft("Show Muted Issues",
-                    m_ProjectAuditor.config.displayMutedIssues, GUILayout.Width(120));
                 if (GUILayout.Button(Styles.MuteButton, GUILayout.ExpandWidth(true), GUILayout.Width(100)))
                 {
                     var selectedItems = m_ActiveIssueTable.GetSelectedItems();
@@ -640,6 +642,14 @@ namespace Unity.ProjectAuditor.Editor
                     foreach (var item in selectedItems) ClearRulesForItem(item);
                 }
 
+                EditorGUILayout.EndHorizontal();
+                
+                EditorGUILayout.BeginHorizontal();
+                EditorGUILayout.LabelField("Show :", GUILayout.ExpandWidth(true), GUILayout.Width(80));
+                m_ProjectAuditor.config.displayOnlyCrititalIssues = EditorGUILayout.ToggleLeft("Only Critical Issues",
+                    m_ProjectAuditor.config.displayOnlyCrititalIssues, GUILayout.Width(160));
+                m_ProjectAuditor.config.displayMutedIssues = EditorGUILayout.ToggleLeft("Muted Issues",
+                    m_ProjectAuditor.config.displayMutedIssues, GUILayout.Width(127));
                 EditorGUILayout.EndHorizontal();
 
                 if (EditorGUI.EndChangeCheck()) shouldRefresh = true;


### PR DESCRIPTION
**Problem**
Depending on the analyzed project, the report can be quite noisy with a lot of issues (thousands) so the user can sometimes be overwhelmed as well as get the wrong picture of the state of the project because of false-positives.

**Solution**
The Performance Critical Context icon helps the user focus on issues that are likely to be more important. The second step, implemented in this PR, is a filter which only shows issues in perf critical code.