### PR TITLE
fix message when there is no issue to display

### DIFF
--- a/Editor/UI/IssueTable.cs
+++ b/Editor/UI/IssueTable.cs
@@ -91,7 +91,7 @@ namespace Unity.ProjectAuditor.Editor
             }
 
             if (!root.hasChildren)
-                root.AddChild(new TreeViewItem(index++, 0, "No elements found"));
+                root.AddChild(new TreeViewItem(index++, 0, "No issue found"));
 
             return root;
         }
@@ -121,7 +121,11 @@ namespace Unity.ProjectAuditor.Editor
 
             var item = treeViewItem as IssueTableItem;
             if (item == null)
+            {
+                if ((Column)column == Column.Description)
+                    EditorGUI.LabelField(cellRect, new GUIContent(treeViewItem.displayName, treeViewItem.displayName));
                 return;
+            }
 
             var issue = item.ProjectIssue;
             var descriptor = item.ProblemDescriptor;


### PR DESCRIPTION
If the list of issues is empty, nothing is displayed. This PR fixes that.