### PR TITLE
Fix double-click on package issues

### DIFF
--- a/Editor/Auditors/ScriptAuditor.cs
+++ b/Editor/Auditors/ScriptAuditor.cs
@@ -21,7 +21,6 @@ namespace Unity.ProjectAuditor.Editor.Auditors
         private readonly ProjectAuditorConfig m_Config;
         private readonly List<IInstructionAnalyzer> m_InstructionAnalyzers = new List<IInstructionAnalyzer>();
         private readonly List<OpCode> m_OpCodes = new List<OpCode>();
-        private string[] m_AssemblyNames;
         private List<ProblemDescriptor> m_ProblemDescriptors;
 
         private Thread m_AssemblyAnalysisThread;
@@ -45,16 +44,12 @@ namespace Unity.ProjectAuditor.Editor.Auditors
             var callCrawler = new CallCrawler();
 
             Profiler.BeginSample("ScriptAuditor.Audit.Compilation");
-            var compiledAssemblyPaths = compilationHelper.Compile(progressBar).Select(Path.GetFullPath);
+            var assemblyInfos = compilationHelper.Compile(progressBar);//.Select(Path.GetFullPath);
             Profiler.EndSample();
 
             var issues = new List<ProjectIssue>();
-            var assemblyInfos = compiledAssemblyPaths.Select(path => new
-            {
-                path, readOnly = AssemblyHelper.IsAssemblyFromReadOnlyPackage(Path.GetFileName(path))
-            });
-            var localAssemblyPaths = assemblyInfos.Where(info => !info.readOnly).Select(info => info.path).ToArray();
-            var readOnlyAssemblyPaths = assemblyInfos.Where(info => info.readOnly).Select(info => info.path).ToArray();
+            var localAssemblyInfos = assemblyInfos.Where(info => !info.readOnly).ToArray();
+            var readOnlyAssemblyInfos = assemblyInfos.Where(info => info.readOnly).ToArray();
 
             var onCallFound = new Action<CallInfo>(pair =>
             {
@@ -77,7 +72,7 @@ namespace Unity.ProjectAuditor.Editor.Auditors
             Profiler.BeginSample("ScriptAuditor.Audit.Analysis");
 
             // first phase: analyze assemblies generated from editable scripts
-            AnalyzeAssemblies(localAssemblyPaths, onCallFound, onIssueFoundInternal, null, progressBar);
+            AnalyzeAssemblies(localAssemblyInfos, onCallFound, onIssueFoundInternal, null, progressBar);
 
             var enableBackgroundAnalysis = m_Config.enableBackgroundAnalysis;
 #if !UNITY_2019_3_OR_NEWER
@@ -87,7 +82,7 @@ namespace Unity.ProjectAuditor.Editor.Auditors
             if (enableBackgroundAnalysis)
             {
                 m_AssemblyAnalysisThread = new Thread(() =>
-                    AnalyzeAssemblies(readOnlyAssemblyPaths, onCallFound, onIssueFound, onCompleteInternal));
+                    AnalyzeAssemblies(readOnlyAssemblyInfos, onCallFound, onIssueFound, onCompleteInternal));
                 m_AssemblyAnalysisThread.Name = "Assembly Analysis";
                 m_AssemblyAnalysisThread.Priority = ThreadPriority.BelowNormal;
                 m_AssemblyAnalysisThread.Start();
@@ -95,15 +90,15 @@ namespace Unity.ProjectAuditor.Editor.Auditors
             else
             {
                 Profiler.BeginSample("ScriptAuditor.Audit.AnalysisReadOnly");
-                AnalyzeAssemblies(readOnlyAssemblyPaths, onCallFound, onIssueFoundInternal, onCompleteInternal, progressBar);
+                AnalyzeAssemblies(readOnlyAssemblyInfos, onCallFound, onIssueFoundInternal, onCompleteInternal, progressBar);
                 Profiler.EndSample();
             }
             Profiler.EndSample();
         }
 
-        private void AnalyzeAssemblies(IEnumerable<string> assemblyPaths, Action<CallInfo> onCallFound, Action<ProjectIssue> onIssueFound, Action<IProgressBar> onComplete, IProgressBar progressBar = null)
+        private void AnalyzeAssemblies(IEnumerable<AssemblyInfo> assemblyInfos, Action<CallInfo> onCallFound, Action<ProjectIssue> onIssueFound, Action<IProgressBar> onComplete, IProgressBar progressBar = null)
         {
-            var compiledAssemblyDirectories = assemblyPaths.Select(Path.GetDirectoryName).Distinct();
+            var compiledAssemblyDirectories = assemblyInfos.Select(info => Path.GetDirectoryName(info.path)).Distinct();
 
             using (var assemblyResolver = new DefaultAssemblyResolver())
             {
@@ -118,22 +113,21 @@ namespace Unity.ProjectAuditor.Editor.Auditors
 
                 if (progressBar != null)
                     progressBar.Initialize("Analyzing Scripts", "Analyzing project scripts",
-                        assemblyPaths.Count());
+                        assemblyInfos.Count());
 
                 // Analyse all Player assemblies
-                foreach (var assemblyPath in assemblyPaths)
+                foreach (var assemblyInfo in assemblyInfos)
                 {
                     if (progressBar != null)
-                        progressBar.AdvanceProgressBar(string.Format("Analyzing {0}",
-                            Path.GetFileName(assemblyPath)));
+                        progressBar.AdvanceProgressBar(string.Format("Analyzing {0}", assemblyInfo.name));
 
-                    if (!File.Exists(assemblyPath))
+                    if (!File.Exists(assemblyInfo.path))
                     {
-                        Debug.LogError(assemblyPath + " not found.");
+                        Debug.LogError(assemblyInfo.path + " not found.");
                         continue;
                     }
 
-                    AnalyzeAssembly(assemblyPath, assemblyResolver, onCallFound, onIssueFound);
+                    AnalyzeAssembly(assemblyInfo, assemblyResolver, onCallFound, onIssueFound);
                 }
             }
 
@@ -168,28 +162,30 @@ namespace Unity.ProjectAuditor.Editor.Auditors
             m_ProblemDescriptors.Add(descriptor);
         }
 
-        private void AnalyzeAssembly(string assemblyPath, IAssemblyResolver assemblyResolver, Action<CallInfo> onCallFound, Action<ProjectIssue> onIssueFound)
+        private void AnalyzeAssembly(AssemblyInfo assemblyInfo, IAssemblyResolver assemblyResolver, Action<CallInfo> onCallFound, Action<ProjectIssue> onIssueFound)
         {
-            Profiler.BeginSample("ScriptAuditor.AnalyzeAssembly " + Path.GetFileNameWithoutExtension(assemblyPath));
+            Profiler.BeginSample("ScriptAuditor.AnalyzeAssembly " + assemblyInfo.name);
 
-            using (var assembly = AssemblyDefinition.ReadAssembly(assemblyPath,
+            using (var assembly = AssemblyDefinition.ReadAssembly(assemblyInfo.path,
                 new ReaderParameters {ReadSymbols = true, AssemblyResolver = assemblyResolver}))
             {
                 var assemblyName = assembly.Name.Name;
+                //   var packageInfo = AssemblyHelper.GetPackageInfoFromAssembly(assemblyName);
+
                 foreach (var methodDefinition in MonoCecilHelper.AggregateAllTypeDefinitions(assembly.MainModule.Types)
                          .SelectMany(t => t.Methods))
                 {
                     if (!methodDefinition.HasBody)
                         continue;
 
-                    AnalyzeMethodBody(assemblyName, methodDefinition, onCallFound, onIssueFound);
+                    AnalyzeMethodBody(assemblyInfo, methodDefinition, onCallFound, onIssueFound);
                 }
             }
 
             Profiler.EndSample();
         }
 
-        private void AnalyzeMethodBody(string assemblyName, MethodDefinition caller, Action<CallInfo> onCallFound, Action<ProjectIssue> onIssueFound)
+        private void AnalyzeMethodBody(AssemblyInfo assemblyInfo, MethodDefinition caller, Action<CallInfo> onCallFound, Action<ProjectIssue> onIssueFound)
         {
             if (!caller.DebugInformation.HasSequencePoints)
                 return;
@@ -212,10 +208,7 @@ namespace Unity.ProjectAuditor.Editor.Auditors
                 Location location = null;
                 if (s != null)
                 {
-                    location = new Location
-                    {
-                        path = s.Document.Url.Replace("\\", "/"), line = s.StartLine
-                    };
+                    location = new Location(AssemblyHelper.ResolveAssetPath(assemblyInfo, s.Document.Url), s.StartLine);
                     callerNode.location = location;
                 }
                 else
@@ -243,7 +236,7 @@ namespace Unity.ProjectAuditor.Editor.Auditors
                             projectIssue.callTree.perfCriticalContext = perfCriticalContext;
                             projectIssue.callTree.AddChild(callerNode);
                             projectIssue.location = location;
-                            projectIssue.assembly = assemblyName;
+                            projectIssue.assembly = assemblyInfo.name;
 
                             onIssueFound(projectIssue);
                         }

--- a/Editor/Auditors/ScriptAuditor.cs
+++ b/Editor/Auditors/ScriptAuditor.cs
@@ -44,7 +44,7 @@ namespace Unity.ProjectAuditor.Editor.Auditors
             var callCrawler = new CallCrawler();
 
             Profiler.BeginSample("ScriptAuditor.Audit.Compilation");
-            var assemblyInfos = compilationHelper.Compile(progressBar);//.Select(Path.GetFullPath);
+            var assemblyInfos = compilationHelper.Compile(progressBar);
             Profiler.EndSample();
 
             var issues = new List<ProjectIssue>();

--- a/Editor/Auditors/SettingsAuditor.cs
+++ b/Editor/Auditors/SettingsAuditor.cs
@@ -113,7 +113,7 @@ namespace Unity.ProjectAuditor.Editor.Auditors
                     descriptor,
                     description,
                     IssueCategory.ProjectSettings,
-                    new Location {path = projectWindowPath}
+                    new Location(projectWindowPath)
                 )
             );
         }

--- a/Editor/ProjectIssue.cs
+++ b/Editor/ProjectIssue.cs
@@ -63,7 +63,7 @@ namespace Unity.ProjectAuditor.Editor
         {
             get
             {
-                return location == null ? string.Empty : location.filename;
+                return location == null ? string.Empty : location.Filename;
             }
         }
 
@@ -71,7 +71,7 @@ namespace Unity.ProjectAuditor.Editor
         {
             get
             {
-                return location == null ? string.Empty : location.relativePath;
+                return location == null ? string.Empty : location.Path;
             }
         }
 
@@ -79,7 +79,7 @@ namespace Unity.ProjectAuditor.Editor
         {
             get
             {
-                return location == null ? 0 : location.line;
+                return location == null ? 0 : location.Line;
             }
         }
 

--- a/Editor/UI/IssueTable.cs
+++ b/Editor/UI/IssueTable.cs
@@ -252,17 +252,7 @@ namespace Unity.ProjectAuditor.Editor
             var issue = issueTableItem.ProjectIssue;
             if (issue.location != null && issue.location.IsValid())
             {
-                if (File.Exists(issue.location.path))
-                {
-                    issue.location.Open();
-                }
-                else
-                {
-#if UNITY_2018_3_OR_NEWER
-                    var window = SettingsService.OpenProjectSettings(issue.location.path);
-                    window.Repaint();
-#endif
-                }
+                issue.location.Open();
             }
         }
 

--- a/Editor/UI/ProjectAuditorWindow.cs
+++ b/Editor/UI/ProjectAuditorWindow.cs
@@ -106,16 +106,16 @@ namespace Unity.ProjectAuditor.Editor
         {
             UnityEngine.Profiling.Profiler.BeginSample("MatchAssembly");
             var matchAssembly = !m_ActiveAnalysisView.desc.showAssemblySelection ||
-                                 m_AssemblySelection != null &&
-                                 (m_AssemblySelection.Contains(issue.assembly) ||
-                                 m_AssemblySelection.ContainsGroup("All"));
+                m_AssemblySelection != null &&
+                (m_AssemblySelection.Contains(issue.assembly) ||
+                    m_AssemblySelection.ContainsGroup("All"));
             UnityEngine.Profiling.Profiler.EndSample();
             if (!matchAssembly)
                 return false;
 
             UnityEngine.Profiling.Profiler.BeginSample("MatchArea");
             var matchArea = m_AreaSelection.Contains(issue.descriptor.area) ||
-                             m_AreaSelection.ContainsGroup("All");
+                m_AreaSelection.ContainsGroup("All");
             UnityEngine.Profiling.Profiler.EndSample();
             if (!matchArea)
                 return false;
@@ -763,7 +763,7 @@ namespace Unity.ProjectAuditor.Editor
                 var compiledAssemblies = m_AssemblyNames.Where(a => !AssemblyHelper.IsModuleAssembly(a));
                 if (AssemblyHelper.IsPackageInfoAvailable())
                     compiledAssemblies = compiledAssemblies.Where(a =>
-                        !AssemblyHelper.IsAssemblyFromReadOnlyPackage(a));
+                        !AssemblyHelper.GetAssemblyInfoFromAssemblyPath(a).readOnly);
                 m_AssemblySelection.selection.AddRange(compiledAssemblies);
 
                 if (!m_AssemblySelection.selection.Any())

--- a/Editor/Unity.ProjectAuditor.Editor.api
+++ b/Editor/Unity.ProjectAuditor.Editor.api
@@ -154,7 +154,7 @@ namespace Unity.ProjectAuditor.Editor.Auditors
     {
         public virtual void Audit(System.Action<Unity.ProjectAuditor.Editor.ProjectIssue> onIssueFound, System.Action onComplete, Unity.ProjectAuditor.Editor.IProgressBar progressBar = default(Unity.ProjectAuditor.Editor.IProgressBar));
         public static System.Collections.Generic.IEnumerable<Unity.ProjectAuditor.Editor.ProjectIssue> FindScriptIssues(Unity.ProjectAuditor.Editor.ProjectReport projectReport, string relativePath);
-        [System.Runtime.CompilerServices.IteratorStateMachine(typeof(Unity.ProjectAuditor.Editor.Auditors.ScriptAuditor.<GetAnalyzerTypes>d__11))] public virtual System.Collections.Generic.IEnumerable<System.Type> GetAnalyzerTypes(System.Reflection.Assembly assembly);
+        [System.Runtime.CompilerServices.IteratorStateMachine(typeof(Unity.ProjectAuditor.Editor.Auditors.ScriptAuditor.<GetAnalyzerTypes>d__10))] public virtual System.Collections.Generic.IEnumerable<System.Type> GetAnalyzerTypes(System.Reflection.Assembly assembly);
         public virtual System.Collections.Generic.IEnumerable<Unity.ProjectAuditor.Editor.ProblemDescriptor> GetDescriptors();
         public virtual void LoadDatabase(string path);
         public virtual void RegisterDescriptor(Unity.ProjectAuditor.Editor.ProblemDescriptor descriptor);
@@ -260,22 +260,33 @@ namespace Unity.ProjectAuditor.Editor.Utils
     public class AssemblyCompilationHelper : System.IDisposable
     {
         public AssemblyCompilationHelper() {}
-        public System.Collections.Generic.IEnumerable<string> Compile(Unity.ProjectAuditor.Editor.IProgressBar progressBar = default(Unity.ProjectAuditor.Editor.IProgressBar));
+        public System.Collections.Generic.IEnumerable<Unity.ProjectAuditor.Editor.Utils.AssemblyInfo> Compile(Unity.ProjectAuditor.Editor.IProgressBar progressBar = default(Unity.ProjectAuditor.Editor.IProgressBar));
         public virtual void Dispose();
         [System.Runtime.CompilerServices.IteratorStateMachine(typeof(Unity.ProjectAuditor.Editor.Utils.AssemblyCompilationHelper.<GetCompiledAssemblyDirectories>d__5))] public System.Collections.Generic.IEnumerable<string> GetCompiledAssemblyDirectories();
     }
 
     public static class AssemblyHelper
     {
-        public static readonly string DefaultAssemblyFileName;
+        public const string DefaultAssemblyFileName = Assembly-CSharp.dll;
         public static string DefaultAssemblyName { get; }
-        [System.Runtime.CompilerServices.IteratorStateMachine(typeof(Unity.ProjectAuditor.Editor.Utils.AssemblyHelper.<GetPrecompiledAssemblyDirectories>d__4))] public static System.Collections.Generic.IEnumerable<string> GetPrecompiledAssemblyDirectories();
+        public static Unity.ProjectAuditor.Editor.Utils.AssemblyInfo GetAssemblyInfoFromAssemblyPath(string assemblyPath);
+        [System.Runtime.CompilerServices.IteratorStateMachine(typeof(Unity.ProjectAuditor.Editor.Utils.AssemblyHelper.<GetPrecompiledAssemblyDirectories>d__5))] public static System.Collections.Generic.IEnumerable<string> GetPrecompiledAssemblyDirectories();
         public static System.Collections.Generic.IEnumerable<string> GetPrecompiledAssemblyPaths();
-        [System.Runtime.CompilerServices.IteratorStateMachine(typeof(Unity.ProjectAuditor.Editor.Utils.AssemblyHelper.<GetPrecompiledEngineAssemblyDirectories>d__6))] public static System.Collections.Generic.IEnumerable<string> GetPrecompiledEngineAssemblyDirectories();
+        [System.Runtime.CompilerServices.IteratorStateMachine(typeof(Unity.ProjectAuditor.Editor.Utils.AssemblyHelper.<GetPrecompiledEngineAssemblyDirectories>d__7))] public static System.Collections.Generic.IEnumerable<string> GetPrecompiledEngineAssemblyDirectories();
         public static System.Collections.Generic.IEnumerable<string> GetPrecompiledEngineAssemblyPaths();
-        public static bool IsAssemblyFromReadOnlyPackage(string assemblyName);
         public static bool IsModuleAssembly(string assemblyName);
         public static bool IsPackageInfoAvailable();
+        public static string ResolveAssetPath(Unity.ProjectAuditor.Editor.Utils.AssemblyInfo assemblyInfo, string path);
+    }
+
+    public struct AssemblyInfo
+    {
+        public string asmDefPath;
+        public string name;
+        public string path;
+        public bool readOnly;
+        public string relativePath;
+        public string[] sourcePaths;
     }
 
     public static class JsonHelper
@@ -287,12 +298,20 @@ namespace Unity.ProjectAuditor.Editor.Utils
 
     public class Location
     {
-        public int line;
-        public string path;
-        public string filename { get; }
-        public string relativePath { get; }
-        public Location() {}
+        public string Filename { get; }
+        public int Line { get; }
+        public string Path { get; }
+        public Unity.ProjectAuditor.Editor.Utils.LocationType Type { get; }
+        public Location(string path, Unity.ProjectAuditor.Editor.Utils.LocationType type = 1) {}
+        public Location(string path, int line, Unity.ProjectAuditor.Editor.Utils.LocationType type = 0) {}
         public bool IsValid();
         public void Open();
+    }
+
+    public enum LocationType
+    {
+        public const Unity.ProjectAuditor.Editor.Utils.LocationType Asset = 0;
+        public const Unity.ProjectAuditor.Editor.Utils.LocationType Setting = 1;
+        public int value__;
     }
 }

--- a/Editor/Utils/AssemblyCompilationHelper.cs
+++ b/Editor/Utils/AssemblyCompilationHelper.cs
@@ -32,7 +32,11 @@ namespace Unity.ProjectAuditor.Editor.Utils
 
         public IEnumerable<AssemblyInfo> Compile(IProgressBar progressBar = null)
         {
+#if UNITY_2018_1_OR_NEWER
             var assemblies = CompilationPipeline.GetAssemblies(AssembliesType.Player);
+#else
+            var assemblies = CompilationPipeline.GetAssemblies();
+#endif
 
 #if UNITY_2018_2_OR_NEWER
             if (progressBar != null)

--- a/Editor/Utils/AssemblyCompilationHelper.cs
+++ b/Editor/Utils/AssemblyCompilationHelper.cs
@@ -30,14 +30,16 @@ namespace Unity.ProjectAuditor.Editor.Utils
             if (!string.IsNullOrEmpty(m_OutputFolder)) Directory.Delete(m_OutputFolder, true);
         }
 
-        public IEnumerable<string> Compile(IProgressBar progressBar = null)
+        public IEnumerable<AssemblyInfo> Compile(IProgressBar progressBar = null)
         {
-            if (EditorUtility.scriptCompilationFailed)
-                throw new AssemblyCompilationException();
+            //var assembly = CompilationPipeline.GetAssemblies(AssembliesType.Player).First(a => a.name.Equals(assemblyInfo.name));
+
+            var assemblies = CompilationPipeline.GetAssemblies(AssembliesType.Player);
+
 #if UNITY_2018_2_OR_NEWER
             if (progressBar != null)
             {
-                var numAssemblies = CompilationPipeline.GetAssemblies(AssembliesType.Player).Length;
+                var numAssemblies = assemblies.Length;
                 progressBar.Initialize("Assembly Compilation", "Compiling project scripts",
                     numAssemblies);
                 m_OnAssemblyCompilationStarted = (s) =>
@@ -64,12 +66,38 @@ namespace Unity.ProjectAuditor.Editor.Utils
             if (!m_Success)
                 throw new AssemblyCompilationException();
 
-            return compilationResult.assemblies.Select(assembly => Path.Combine(m_OutputFolder, assembly));
+            // TODO: check assemblies is consistent with compilationResult
+            if (assemblies.Length != compilationResult.assemblies.Count)
+            {
+                assemblies = assemblies;
+            }
+
+            // return compilationResult.assemblies.Select(assembly => AssemblyHelper.GetPackageInfoFromAssemblyPath(Path.Combine(m_OutputFolder, assembly)));
+            var compiledAssemblyPaths = compilationResult.assemblies.Select(assembly => Path.Combine(m_OutputFolder, assembly));
 #else
             // fallback to CompilationPipeline assemblies
-            return CompilationPipeline.GetAssemblies()
+            var compiledAssemblyPaths = CompilationPipeline.GetAssemblies()
                 .Where(a => a.flags != AssemblyFlags.EditorAssembly).Select(assembly => assembly.outputPath);
 #endif
+
+            var assemblyInfos = new List<AssemblyInfo>();
+            foreach (var compiledAssemblyPath in compiledAssemblyPaths)
+            {
+                var assemblyInfo = AssemblyHelper.GetAssemblyInfoFromAssemblyPath(compiledAssemblyPath);
+                var assembly = assemblies.FirstOrDefault(a => a.name.Equals(assemblyInfo.name));
+                if (assembly == null)
+                    assembly = assembly;
+                var test = assembly.sourceFiles.Where(path => !path.Contains(assemblyInfo.relativePath)).ToArray();
+                if (test.Length > 0)
+                {
+                    test = test;
+                }
+                var sourcePaths = assembly.sourceFiles.Select(file => file.Remove(0, assemblyInfo.relativePath.Length + 1));
+                assemblyInfo.sourcePaths = sourcePaths.ToArray();
+                assemblyInfos.Add(assemblyInfo);
+            }
+
+            return assemblyInfos;
         }
 
         public IEnumerable<string> GetCompiledAssemblyDirectories()

--- a/Editor/Utils/AssemblyCompilationHelper.cs
+++ b/Editor/Utils/AssemblyCompilationHelper.cs
@@ -32,8 +32,6 @@ namespace Unity.ProjectAuditor.Editor.Utils
 
         public IEnumerable<AssemblyInfo> Compile(IProgressBar progressBar = null)
         {
-            //var assembly = CompilationPipeline.GetAssemblies(AssembliesType.Player).First(a => a.name.Equals(assemblyInfo.name));
-
             var assemblies = CompilationPipeline.GetAssemblies(AssembliesType.Player);
 
 #if UNITY_2018_2_OR_NEWER
@@ -66,12 +64,6 @@ namespace Unity.ProjectAuditor.Editor.Utils
             if (!m_Success)
                 throw new AssemblyCompilationException();
 
-            // TODO: check assemblies is consistent with compilationResult
-            if (assemblies.Length != compilationResult.assemblies.Count)
-            {
-                assemblies = assemblies;
-            }
-
             // return compilationResult.assemblies.Select(assembly => AssemblyHelper.GetPackageInfoFromAssemblyPath(Path.Combine(m_OutputFolder, assembly)));
             var compiledAssemblyPaths = compilationResult.assemblies.Select(assembly => Path.Combine(m_OutputFolder, assembly));
 #else
@@ -84,15 +76,9 @@ namespace Unity.ProjectAuditor.Editor.Utils
             foreach (var compiledAssemblyPath in compiledAssemblyPaths)
             {
                 var assemblyInfo = AssemblyHelper.GetAssemblyInfoFromAssemblyPath(compiledAssemblyPath);
-                var assembly = assemblies.FirstOrDefault(a => a.name.Equals(assemblyInfo.name));
-                if (assembly == null)
-                    assembly = assembly;
-                var test = assembly.sourceFiles.Where(path => !path.Contains(assemblyInfo.relativePath)).ToArray();
-                if (test.Length > 0)
-                {
-                    test = test;
-                }
+                var assembly = assemblies.First(a => a.name.Equals(assemblyInfo.name));
                 var sourcePaths = assembly.sourceFiles.Select(file => file.Remove(0, assemblyInfo.relativePath.Length + 1));
+
                 assemblyInfo.sourcePaths = sourcePaths.ToArray();
                 assemblyInfos.Add(assemblyInfo);
             }

--- a/Editor/Utils/AssemblyCompilationHelper.cs
+++ b/Editor/Utils/AssemblyCompilationHelper.cs
@@ -64,7 +64,6 @@ namespace Unity.ProjectAuditor.Editor.Utils
             if (!m_Success)
                 throw new AssemblyCompilationException();
 
-            // return compilationResult.assemblies.Select(assembly => AssemblyHelper.GetPackageInfoFromAssemblyPath(Path.Combine(m_OutputFolder, assembly)));
             var compiledAssemblyPaths = compilationResult.assemblies.Select(assembly => Path.Combine(m_OutputFolder, assembly));
 #else
             // fallback to CompilationPipeline assemblies

--- a/Editor/Utils/AssemblyHelper.cs
+++ b/Editor/Utils/AssemblyHelper.cs
@@ -5,15 +5,19 @@ using System.Linq;
 using UnityEditor;
 using UnityEditor.Compilation;
 
-#if UNITY_2019_3_OR_NEWER
+//#if UNITY_2019_3_OR_NEWER
 using UnityEditor.PackageManager;
-#endif
+using UnityEngine;
+
+//#endif
 
 namespace Unity.ProjectAuditor.Editor.Utils
 {
     public static class AssemblyHelper
     {
-        public static readonly string DefaultAssemblyFileName = "Assembly-CSharp.dll";
+        public const string DefaultAssemblyFileName = "Assembly-CSharp.dll";
+
+        const string BuiltInPackagesFolder = "BuiltInPackages";
 
         public static string DefaultAssemblyName
         {
@@ -82,20 +86,71 @@ namespace Unity.ProjectAuditor.Editor.Utils
             return GetPrecompiledEngineAssemblyPaths().FirstOrDefault(a => a.Contains(assemblyName)) != null;
         }
 
-        public static bool IsAssemblyFromReadOnlyPackage(string assemblyName)
+        public static AssemblyInfo GetAssemblyInfoFromAssemblyPath(string assemblyPath)
         {
+            // by default let's assume it's not a package
+            var assemblyInfo = new AssemblyInfo
+            {
+                name = Path.GetFileNameWithoutExtension(assemblyPath),
+                path = assemblyPath,
+                relativePath = "Assets",
+                readOnly = false
+            };
+
+            var asmDefPath = CompilationPipeline.GetAssemblyDefinitionFilePathFromAssemblyName(assemblyInfo.name);
+            if (asmDefPath != null)
+            {
+                assemblyInfo.asmDefPath = asmDefPath;
+                var folders = asmDefPath.Split('/');
+                if (folders.Length > 2 && folders[0].Equals("Packages"))
+                {
+                    assemblyInfo.relativePath = Path.Combine(folders[0], folders[1]);
 #if UNITY_2019_3_OR_NEWER
-            var module = AppDomain.CurrentDomain.GetAssemblies().SelectMany(a => a.Modules).FirstOrDefault(a => a.Name.Contains(assemblyName));
-            if (module == null)
-                return false;
-            var info =  UnityEditor.PackageManager.PackageInfo.FindForAssembly(module.Assembly);
-            if (info == null)
-                return false;
-            return info.source != PackageSource.Embedded;
+                    var info =  UnityEditor.PackageManager.PackageInfo.FindForAssetPath(asmDefPath);
+                    if (info != null)
+                    {
+                        assemblyInfo.readOnly = info.source != PackageSource.Embedded && info.source != PackageSource.Local;
+                    }
 #else
-            // assume it's not a package
-            return false;
+                    assemblyInfo.readOnly = true;
 #endif
+                }
+                else
+                {
+                    assemblyInfo = assemblyInfo;
+                }
+            }
+            else
+            {
+                // default assembly
+            }
+
+            return assemblyInfo;
+        }
+
+        public static string ResolveAssetPath(AssemblyInfo assemblyInfo, string path)
+        {
+            // sanitize path
+            path = path.Replace("\\", "/");
+
+            if (!string.IsNullOrEmpty(assemblyInfo.asmDefPath) && assemblyInfo.asmDefPath.StartsWith("Packages"))
+            {
+                var asmDefFolder = Path.GetDirectoryName(assemblyInfo.asmDefPath.Remove(0, assemblyInfo.relativePath.Length + 1));
+                if (path.IndexOf(asmDefFolder) < 0)
+                {
+                    // handle source files that are not located with asmdef
+                    return Path.Combine(assemblyInfo.relativePath, assemblyInfo.sourcePaths.First(sourcePath => path.Contains(sourcePath)));
+                }
+                return Path.Combine(assemblyInfo.relativePath, path.Substring(path.IndexOf(asmDefFolder)));
+            }
+            if (path.Contains(BuiltInPackagesFolder))
+            {
+                return path.Remove(0, path.IndexOf(BuiltInPackagesFolder) + BuiltInPackagesFolder.Length);
+            }
+
+            // remove Assets folder
+            var projectPath = Path.GetDirectoryName(Application.dataPath);
+            return path.Remove(0, projectPath.Length + 1);
         }
     }
 }

--- a/Editor/Utils/AssemblyHelper.cs
+++ b/Editor/Utils/AssemblyHelper.cs
@@ -4,12 +4,7 @@ using System.IO;
 using System.Linq;
 using UnityEditor;
 using UnityEditor.Compilation;
-
-//#if UNITY_2019_3_OR_NEWER
-using UnityEditor.PackageManager;
 using UnityEngine;
-
-//#endif
 
 namespace Unity.ProjectAuditor.Editor.Utils
 {
@@ -109,7 +104,7 @@ namespace Unity.ProjectAuditor.Editor.Utils
                     var info =  UnityEditor.PackageManager.PackageInfo.FindForAssetPath(asmDefPath);
                     if (info != null)
                     {
-                        assemblyInfo.readOnly = info.source != PackageSource.Embedded && info.source != PackageSource.Local;
+                        assemblyInfo.readOnly = info.source != UnityEditor.PackageManager.PackageSource.Embedded && info.source != UnityEditor.PackageManager.PackageSource.Local;
                     }
 #else
                     assemblyInfo.readOnly = true;
@@ -117,7 +112,7 @@ namespace Unity.ProjectAuditor.Editor.Utils
                 }
                 else
                 {
-                    assemblyInfo = assemblyInfo;
+                    // non-package user-defined assembly
                 }
             }
             else

--- a/Editor/Utils/AssemblyInfo.cs
+++ b/Editor/Utils/AssemblyInfo.cs
@@ -1,0 +1,14 @@
+using System.Collections.Generic;
+
+namespace Unity.ProjectAuditor.Editor.Utils
+{
+    public struct AssemblyInfo
+    {
+        public string name;            // assembly name without extension
+        public string path;            // absolute path
+        public string asmDefPath;
+        public string relativePath;
+        public bool readOnly;
+        public string[] sourcePaths;
+    }
+}

--- a/Editor/Utils/AssemblyInfo.cs.meta
+++ b/Editor/Utils/AssemblyInfo.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 2ca44a4098e64e3eb75befd7c64d2039
+timeCreated: 1587042447

--- a/Tests/Editor/AssemblyHelperTests.cs
+++ b/Tests/Editor/AssemblyHelperTests.cs
@@ -44,6 +44,7 @@ namespace UnityEditor.ProjectAuditor.EditorTests
             Assert.NotNull(paths.FirstOrDefault(path => path.Contains("UnityEngine.CoreModule.dll")));
         }
 
+#if UNITY_2018_1_OR_NEWER
         [Test]
         public void DefaultAssemblyInfoIsCorrect()
         {
@@ -65,5 +66,6 @@ namespace UnityEditor.ProjectAuditor.EditorTests
             Assert.IsTrue(assemblyInfo.asmDefPath.Equals("Packages/com.unity.project-auditor/Editor/Unity.ProjectAuditor.Editor.asmdef"));
             Assert.IsTrue(assemblyInfo.relativePath.Equals("Packages/com.unity.project-auditor"));
         }
+#endif
     }
 }

--- a/Tests/Editor/AssemblyHelperTests.cs
+++ b/Tests/Editor/AssemblyHelperTests.cs
@@ -1,6 +1,8 @@
+using System.IO;
 using System.Linq;
 using NUnit.Framework;
 using Unity.ProjectAuditor.Editor.Utils;
+using UnityEditor.Compilation;
 
 namespace UnityEditor.ProjectAuditor.EditorTests
 {
@@ -26,10 +28,10 @@ namespace UnityEditor.ProjectAuditor.EditorTests
         {
             using (var compilationHelper = new AssemblyCompilationHelper())
             {
-                var paths = compilationHelper.Compile();
+                var assemblyInfos = compilationHelper.Compile();
 
-                Assert.Positive(paths.Count());
-                Assert.NotNull(paths.FirstOrDefault(path => path.Contains(AssemblyHelper.DefaultAssemblyFileName)));
+                Assert.Positive(assemblyInfos.Count());
+                Assert.NotNull(assemblyInfos.FirstOrDefault(info => info.name.Contains(AssemblyHelper.DefaultAssemblyFileName)));
             }
         }
 
@@ -40,6 +42,28 @@ namespace UnityEditor.ProjectAuditor.EditorTests
 
             Assert.Positive(paths.Count());
             Assert.NotNull(paths.FirstOrDefault(path => path.Contains("UnityEngine.CoreModule.dll")));
+        }
+
+        [Test]
+        public void DefaultAssemblyInfoIsCorrect()
+        {
+            var assembly = CompilationPipeline.GetAssemblies(AssembliesType.Player).FirstOrDefault(a => a.name.Equals(Path.GetFileNameWithoutExtension(AssemblyHelper.DefaultAssemblyFileName)));
+            var assemblyInfo = AssemblyHelper.GetAssemblyInfoFromAssemblyPath(assembly.outputPath);
+
+            Assert.IsTrue(assemblyInfo.path.Equals("Library/ScriptAssemblies/Assembly-CSharp.dll"));
+            Assert.IsNull(assemblyInfo.asmDefPath);
+            Assert.IsFalse(assemblyInfo.readOnly);
+        }
+
+        [Test]
+        public void PackageAssemblyInfoIsCorrect()
+        {
+            var assembly = CompilationPipeline.GetAssemblies(AssembliesType.Editor).FirstOrDefault(a => a.name.Equals("Unity.ProjectAuditor.Editor"));
+            var assemblyInfo = AssemblyHelper.GetAssemblyInfoFromAssemblyPath(assembly.outputPath);
+
+            Assert.IsTrue(assemblyInfo.path.Equals("Library/ScriptAssemblies/Unity.ProjectAuditor.Editor.dll"));
+            Assert.IsTrue(assemblyInfo.asmDefPath.Equals("Packages/com.unity.project-auditor/Editor/Unity.ProjectAuditor.Editor.asmdef"));
+            Assert.IsTrue(assemblyInfo.relativePath.Equals("Packages/com.unity.project-auditor"));
         }
     }
 }

--- a/Tests/Editor/LocationTests.cs
+++ b/Tests/Editor/LocationTests.cs
@@ -8,14 +8,6 @@ namespace UnityEditor.ProjectAuditor.EditorTests
 {
     public class LocationTests
     {
-        // [Test]
-        // public void LocationIsValid()
-        // {
-        //     var location = new Location("some/path");
-        //     Assert.IsTrue(location.IsValid());
-        //     Assert.IsTrue(location.Type == LocationType.Asset);
-        // }
-
         [Test]
         public void AssetLocationIsValid()
         {
@@ -34,66 +26,5 @@ namespace UnityEditor.ProjectAuditor.EditorTests
             Assert.IsTrue(location.Path.Equals("Project/Player"));
             Assert.IsTrue(location.Type == LocationType.Setting);
         }
-
-        // [Test]
-        // public void LocationRelativePathFromBuiltInPackage()
-        // {
-        //     var location = new Location
-        //     {
-        //         path = "some/path/BuiltInPackages/com.unity.mypackage"
-        //     };
-        //     Assert.IsTrue(location.Path.Equals("com.unity.mypackage"));
-        // }
-
-        // [Test]
-        // public void LocationRelativePathFromAssets()
-        // {
-        //     var location = new Location
-        //     {
-        //         path = Path.Combine(Application.dataPath, "file.cs")
-        //     };
-        //     Assert.IsTrue(location.relativePath.Equals("Assets/file.cs"));
-        // }
-
-        /*  [Test]
-          public void UninitializedLocationIsNotValid()
-          {
-              var location = new Location(null);
-              Assert.IsFalse(location.IsValid());
-          }
-
-          [Test]
-          public void UninitializedLocationFilenameIsEmpty()
-          {
-              var location = new Location(null);
-              Assert.IsTrue(location.Filename.Equals(string.Empty));
-          }
-
-          [Test]
-          public void UninitializedLocationRelativePathIsEmpty()
-          {
-              var location = new Location();
-              Assert.IsTrue(location.Path.Equals(string.Empty));
-          }
-                                               */
-        // [Test]
-        // public void LocationAssetDatabasePathIsCorrect()
-        // {
-        //     var location = new Location
-        //     {
-        //         path = "Assets/Dummy.cs"
-        //     };
-        //     Assert.IsTrue(location.assetDatabasePath.Equals("Assets/Dummy.cs"));
-        // }
-
-        // [Test]
-        // public void LocationAssetDatabasePathFromPackageIsCorrect()
-        // {
-        //     var location = new Location
-        //     {
-        //         path = "Library/PackageCache/com.unity.mypackage@0.0.0-preview.1/Unity.MyPackage/Dummy.cs"
-        //     };
-        //     Assert.IsTrue(location.assetDatabasePath.Equals("Packages/com.unity.mypackage/Unity.MyPackage/Dummy.cs"));
-        // }
     }
 }

--- a/Tests/Editor/LocationTests.cs
+++ b/Tests/Editor/LocationTests.cs
@@ -1,0 +1,99 @@
+using System;
+using System.IO;
+using NUnit.Framework;
+using Unity.ProjectAuditor.Editor.Utils;
+using UnityEngine;
+
+namespace UnityEditor.ProjectAuditor.EditorTests
+{
+    public class LocationTests
+    {
+        // [Test]
+        // public void LocationIsValid()
+        // {
+        //     var location = new Location("some/path");
+        //     Assert.IsTrue(location.IsValid());
+        //     Assert.IsTrue(location.Type == LocationType.Asset);
+        // }
+
+        [Test]
+        public void AssetLocationIsValid()
+        {
+            var location = new Location("some/path/file.cs", 0);
+            Assert.IsTrue(location.IsValid());
+            Assert.IsTrue(location.Filename.Equals("file.cs"));
+            Assert.IsTrue(location.Path.Equals("some/path/file.cs"));
+            Assert.IsTrue(location.Type == LocationType.Asset);
+        }
+
+        [Test]
+        public void SettingLocationIsValid()
+        {
+            var location = new Location("Project/Player");
+            Assert.IsTrue(location.IsValid());
+            Assert.IsTrue(location.Path.Equals("Project/Player"));
+            Assert.IsTrue(location.Type == LocationType.Setting);
+        }
+
+        // [Test]
+        // public void LocationRelativePathFromBuiltInPackage()
+        // {
+        //     var location = new Location
+        //     {
+        //         path = "some/path/BuiltInPackages/com.unity.mypackage"
+        //     };
+        //     Assert.IsTrue(location.Path.Equals("com.unity.mypackage"));
+        // }
+
+        // [Test]
+        // public void LocationRelativePathFromAssets()
+        // {
+        //     var location = new Location
+        //     {
+        //         path = Path.Combine(Application.dataPath, "file.cs")
+        //     };
+        //     Assert.IsTrue(location.relativePath.Equals("Assets/file.cs"));
+        // }
+
+        /*  [Test]
+          public void UninitializedLocationIsNotValid()
+          {
+              var location = new Location(null);
+              Assert.IsFalse(location.IsValid());
+          }
+
+          [Test]
+          public void UninitializedLocationFilenameIsEmpty()
+          {
+              var location = new Location(null);
+              Assert.IsTrue(location.Filename.Equals(string.Empty));
+          }
+
+          [Test]
+          public void UninitializedLocationRelativePathIsEmpty()
+          {
+              var location = new Location();
+              Assert.IsTrue(location.Path.Equals(string.Empty));
+          }
+                                               */
+        // [Test]
+        // public void LocationAssetDatabasePathIsCorrect()
+        // {
+        //     var location = new Location
+        //     {
+        //         path = "Assets/Dummy.cs"
+        //     };
+        //     Assert.IsTrue(location.assetDatabasePath.Equals("Assets/Dummy.cs"));
+        // }
+
+        // [Test]
+        // public void LocationAssetDatabasePathFromPackageIsCorrect()
+        // {
+        //     var location = new Location
+        //     {
+        //         path = "Library/PackageCache/com.unity.mypackage@0.0.0-preview.1/Unity.MyPackage/Dummy.cs"
+        //     };
+        //     Assert.IsTrue(location.assetDatabasePath.Equals("Packages/com.unity.mypackage/Unity.MyPackage/Dummy.cs"));
+        // }
+    }
+}

--- a/Tests/Editor/LocationTests.cs.meta
+++ b/Tests/Editor/LocationTests.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 0b22439f679b4c3293bc0fbaf3485e9a
+timeCreated: 1586955026

--- a/Tests/Editor/SettingIssueTests.cs
+++ b/Tests/Editor/SettingIssueTests.cs
@@ -24,7 +24,7 @@ namespace UnityEditor.ProjectAuditor.EditorTests
             var fixedDeltaTimeIssue = issues.FirstOrDefault(i => i.descriptor.method.Equals("fixedDeltaTime"));
             Assert.NotNull(fixedDeltaTimeIssue);
             Assert.True(fixedDeltaTimeIssue.description.Equals("UnityEngine.Time.fixedDeltaTime: 0.02"));
-            Assert.True(fixedDeltaTimeIssue.location.path.Equals("Project/Time"));
+            Assert.True(fixedDeltaTimeIssue.location.Path.Equals("Project/Time"));
 
             // "fix" fixedDeltaTime so it's not reported anymore
             Time.fixedDeltaTime = 0.021f;
@@ -37,7 +37,7 @@ namespace UnityEditor.ProjectAuditor.EditorTests
                 issues.FirstOrDefault(i => i.descriptor.method.Equals("stripEngineCode"));
             Assert.NotNull(playerSettingIssue);
             Assert.True(playerSettingIssue.description.Equals("UnityEditor.PlayerSettings.stripEngineCode: False"));
-            Assert.True(playerSettingIssue.location.path.Equals("Project/Player"));
+            Assert.True(playerSettingIssue.location.Path.Equals("Project/Player"));
         }
     }
 }


### PR DESCRIPTION
**Problem**
Double-clicking on package issues does not work when packages are not fetched from a registry.

**Solution**
This PR changes how file paths are resolved to asset paths in the Unity project since AssetDatabase expects all Packages to follow the syntax: Packages/com.unity.mypackage regardless of the physical location which could be:
- Library/PackageCache folder (read-only packages)
- in the project, like CustomPackages/com.unity.mypackage (Local packages)
- Packages folder (Embedded)
- Unity installation folder (built-in packages)
