### PR TITLE
Add shader warmup issues

### DIFF
--- a/Data/ApiDatabase.json
+++ b/Data/ApiDatabase.json
@@ -2269,6 +2269,26 @@
             "area": "Memory",
             "problem": "String concatenation operations allocates managed memory",
             "solution": "Try to avoid concatenating strings in frequently-updated code. Prefer using a StringBuilder instead, as this minimizes managed allocations."
-        }
+        },
+        {
+          "id": 101227,
+          "type": "UnityEngine.Shader",
+          "method": "WarmupAllShaders",
+          "value": "",
+          "customevaluator": "",
+          "area": "CPU",
+          "problem": "WarmupAllShaders does not work properly on Metal and Vulkan. This might result in unexpected CPU spikes due to shader compilation.",
+          "solution": "Implement a shader pre-warming mechanism which renders a small triangle for each combination of vertex format and shader used at runtime."
+        },
+      {
+        "id": 101228,
+        "type": "UnityEngine.ShaderVariantCollection",
+        "method": "WarmUp",
+        "value": "",
+        "customevaluator": "",
+        "area": "CPU",
+        "problem": "WarmUp does not work properly on Metal and Vulkan. This might result in unexpected CPU spikes due to shader compilation.",
+        "solution": "Implement a shader pre-warming mechanism which renders a small triangle for each combination of vertex format and shader variant used at runtime."
+      }
     ]
 }


### PR DESCRIPTION
ShaderVariantCollection.WarmUp() and Shader.WarmupAllShaders() don't work properly on Metal and Vulkan API. This might result in unexpected CPU spikes due to shader compilation.

Note that we need to update the global list of issues.