### PR TITLE
Double-click on asset to focus in project browser

### DIFF
--- a/Editor/Auditors/AssetsAuditor.cs
+++ b/Editor/Auditors/AssetsAuditor.cs
@@ -71,7 +71,7 @@ namespace Unity.ProjectAuditor.Editor.Auditors
 
             foreach (var assetPath in resourceAssetPathsHashSet)
             {
-                var location = new Location(assetPath, LocationType.Asset);
+                var location = new Location(assetPath);
                 onIssueFound(new ProjectIssue
                     (
                         s_Descriptor,

--- a/Editor/UI/AnalysisView.cs
+++ b/Editor/UI/AnalysisView.cs
@@ -1,5 +1,7 @@
+using System;
 using System.Collections.Generic;
 using System.Linq;
+using Unity.ProjectAuditor.Editor.Utils;
 using UnityEditor;
 using UnityEditor.IMGUI.Controls;
 using UnityEngine;
@@ -18,6 +20,7 @@ namespace Unity.ProjectAuditor.Editor.UI
         public bool showInvertedCallTree;
         public bool showRightPanels;
         public IssueTable.Column[] columnDescriptors;
+        public Action<Location> onDoubleClick;
         public ProjectAuditorAnalytics.UIButton analyticsEvent;
     }
 

--- a/Editor/UI/CallHierarchyView.cs
+++ b/Editor/UI/CallHierarchyView.cs
@@ -1,5 +1,7 @@
+using System;
 using System.Collections.Generic;
 using Unity.ProjectAuditor.Editor.CodeAnalysis;
+using Unity.ProjectAuditor.Editor.Utils;
 using UnityEditor.IMGUI.Controls;
 
 namespace Unity.ProjectAuditor.Editor.UI
@@ -8,10 +10,12 @@ namespace Unity.ProjectAuditor.Editor.UI
     {
         private readonly Dictionary<int, CallTreeNode> m_CallTreeDictionary = new Dictionary<int, CallTreeNode>();
         private CallTreeNode m_CallTree;
+        private Action<Location> m_OnDoubleClick;
 
-        public CallHierarchyView(TreeViewState treeViewState)
+        public CallHierarchyView(TreeViewState treeViewState, Action<Location> onDoubleClick)
             : base(treeViewState)
         {
+            m_OnDoubleClick = onDoubleClick;
             Reload();
         }
 
@@ -61,7 +65,7 @@ namespace Unity.ProjectAuditor.Editor.UI
             {
                 var node = m_CallTreeDictionary[id];
                 if (node.location != null)
-                    node.location.Open();
+                    m_OnDoubleClick(node.location);
             }
         }
     }

--- a/Editor/UI/IssueTable.cs
+++ b/Editor/UI/IssueTable.cs
@@ -311,7 +311,7 @@ namespace Unity.ProjectAuditor.Editor.UI
             var issue = issueTableItem.ProjectIssue;
             if (issue.location != null && issue.location.IsValid())
             {
-                issue.location.Open();
+                m_Desc.onDoubleClick(issue.location);
             }
         }
 

--- a/Editor/UI/ProjectAuditorWindow.cs
+++ b/Editor/UI/ProjectAuditorWindow.cs
@@ -55,6 +55,7 @@ namespace Unity.ProjectAuditor.Editor.UI
                     IssueTable.Column.FileType,
                     IssueTable.Column.Path
                 },
+                onDoubleClick = FocusOnAsset,
                 analyticsEvent = ProjectAuditorAnalytics.UIButton.Assets
             },
             new AnalysisViewDescriptor
@@ -75,6 +76,7 @@ namespace Unity.ProjectAuditor.Editor.UI
                     IssueTable.Column.Filename,
                     IssueTable.Column.Assembly
                 },
+                onDoubleClick = OpenTextFile,
                 analyticsEvent = ProjectAuditorAnalytics.UIButton.ApiCalls
             },
             new AnalysisViewDescriptor
@@ -92,6 +94,7 @@ namespace Unity.ProjectAuditor.Editor.UI
                     IssueTable.Column.Description,
                     IssueTable.Column.Area,
                 },
+                onDoubleClick = OpenProjectSettings,
                 analyticsEvent = ProjectAuditorAnalytics.UIButton.ProjectSettings
             }
         };
@@ -248,7 +251,7 @@ namespace Unity.ProjectAuditor.Editor.UI
                 m_AnalysisViews.Add(view);
             }
 
-            m_CallHierarchyView = new CallHierarchyView(new TreeViewState());
+            m_CallHierarchyView = new CallHierarchyView(new TreeViewState(), OpenTextFile);
 
             RefreshDisplay();
         }
@@ -1043,6 +1046,34 @@ namespace Unity.ProjectAuditor.Editor.UI
                 m_Preferences.emptyGroups = EditorGUILayout.ToggleLeft("Show Empty Groups",
                     m_Preferences.emptyGroups, GUILayout.Width(100));
                 EditorGUILayout.EndHorizontal();
+            }
+        }
+
+        static void OpenTextFile(Location location)
+        {
+            UnityEngine.Object obj = AssetDatabase.LoadAssetAtPath<TextAsset>(location.Path);
+            if (obj != null)
+            {
+                // open text file in the text editor
+                AssetDatabase.OpenAsset(obj, location.Line);
+            }
+        }
+
+        static void OpenProjectSettings(Location location)
+        {
+#if UNITY_2018_3_OR_NEWER
+            var window = SettingsService.OpenProjectSettings(location.Path);
+            window.Repaint();
+#endif
+        }
+
+        static void FocusOnAsset(Location location)
+        {
+            // focus asset in the project window
+            var obj = AssetDatabase.LoadMainAssetAtPath(location.Path);
+            if (obj != null)
+            {
+                ProjectWindowUtil.ShowCreatedAsset(obj);
             }
         }
 

--- a/Editor/UI/ProjectAuditorWindow.cs
+++ b/Editor/UI/ProjectAuditorWindow.cs
@@ -1051,7 +1051,7 @@ namespace Unity.ProjectAuditor.Editor.UI
 
         static void OpenTextFile(Location location)
         {
-            UnityEngine.Object obj = AssetDatabase.LoadAssetAtPath<TextAsset>(location.Path);
+            var obj = AssetDatabase.LoadAssetAtPath<TextAsset>(location.Path);
             if (obj != null)
             {
                 // open text file in the text editor

--- a/Editor/Unity.ProjectAuditor.Editor.api
+++ b/Editor/Unity.ProjectAuditor.Editor.api
@@ -206,7 +206,6 @@ namespace Unity.ProjectAuditor.Editor.Utils
         public string Path { get; }
         public Unity.ProjectAuditor.Editor.Utils.LocationType Type { get; }
         public bool IsValid();
-        public void Open();
     }
 
     public enum LocationType

--- a/Editor/Unity.ProjectAuditor.Editor.api
+++ b/Editor/Unity.ProjectAuditor.Editor.api
@@ -204,14 +204,6 @@ namespace Unity.ProjectAuditor.Editor.Utils
         public string Filename { get; }
         public int Line { get; }
         public string Path { get; }
-        public Unity.ProjectAuditor.Editor.Utils.LocationType Type { get; }
         public bool IsValid();
-    }
-
-    public enum LocationType
-    {
-        public const Unity.ProjectAuditor.Editor.Utils.LocationType Asset = 0;
-        public const Unity.ProjectAuditor.Editor.Utils.LocationType Setting = 1;
-        public int value__;
     }
 }

--- a/Editor/Utils/Location.cs
+++ b/Editor/Utils/Location.cs
@@ -73,23 +73,5 @@ namespace Unity.ProjectAuditor.Editor.Utils
         {
             return !string.IsNullOrEmpty(m_Path);
         }
-
-        public void Open()
-        {
-            if (m_Type == LocationType.Setting)
-            {
-#if UNITY_2018_3_OR_NEWER
-                var window = SettingsService.OpenProjectSettings(m_Path);
-                window.Repaint();
-#endif
-            }
-            else if (File.Exists(m_Path))
-            {
-                UnityEngine.Object obj = AssetDatabase.LoadAssetAtPath<TextAsset>(m_Path);
-                if (obj == null)
-                    obj = AssetDatabase.LoadMainAssetAtPath(m_Path);
-                AssetDatabase.OpenAsset(obj, m_Line);
-            }
-        }
     }
 }

--- a/Editor/Utils/Location.cs
+++ b/Editor/Utils/Location.cs
@@ -5,18 +5,11 @@ using UnityEngine;
 
 namespace Unity.ProjectAuditor.Editor.Utils
 {
-    public enum LocationType
-    {
-        Asset,
-        Setting
-    }
-
     [Serializable]
     public class Location
     {
         [SerializeField] private int m_Line;
         [SerializeField] private string m_Path; // path relative to the project folder
-        [SerializeField] private LocationType m_Type;
 
         public string Filename
         {
@@ -48,25 +41,15 @@ namespace Unity.ProjectAuditor.Editor.Utils
             }
         }
 
-        public LocationType Type
-        {
-            get
-            {
-                return m_Type;
-            }
-        }
-
-        internal Location(string path, LocationType type = LocationType.Setting)
+        internal Location(string path)
         {
             m_Path = path;
-            m_Type = type;
         }
 
-        internal Location(string path, int line, LocationType type = LocationType.Asset)
+        internal Location(string path, int line)
         {
             m_Path = path;
             m_Line = line;
-            m_Type = type;
         }
 
         public bool IsValid()

--- a/Tests/Editor/LocationTests.cs
+++ b/Tests/Editor/LocationTests.cs
@@ -15,7 +15,6 @@ namespace UnityEditor.ProjectAuditor.EditorTests
             Assert.IsTrue(location.IsValid());
             Assert.IsTrue(location.Filename.Equals("file.cs"));
             Assert.IsTrue(location.Path.Equals("some/path/file.cs"));
-            Assert.IsTrue(location.Type == LocationType.Asset);
         }
 
         [Test]
@@ -24,7 +23,6 @@ namespace UnityEditor.ProjectAuditor.EditorTests
             var location = new Location("Project/Player");
             Assert.IsTrue(location.IsValid());
             Assert.IsTrue(location.Path.Equals("Project/Player"));
-            Assert.IsTrue(location.Type == LocationType.Setting);
         }
     }
 }


### PR DESCRIPTION
Double-clicking on an asset-specific issue opens the file with the associated application. With this change, double-click on the asset will focus the project browser window on the asset.
