### PR TITLE
Move call tree to the bottom of the window

### DIFF
--- a/Editor/UI/ProjectAuditorWindow.cs
+++ b/Editor/UI/ProjectAuditorWindow.cs
@@ -444,6 +444,15 @@ namespace Unity.ProjectAuditor.Editor.UI
 
         private void DrawIssues()
         {
+            ProblemDescriptor problemDescriptor = null;
+            var selectedItems = m_ActiveIssueTable.GetSelectedItems();
+            var selectedDescriptors = selectedItems.Select(i => i.ProblemDescriptor);
+            var selectedIssues = selectedItems.Select(i => i.ProjectIssue);
+            // find out if all descriptors are the same
+            var firstDescriptor = selectedDescriptors.FirstOrDefault();
+            if (selectedDescriptors.Count() == selectedDescriptors.Count(d => d.id == firstDescriptor.id))
+                problemDescriptor = firstDescriptor;
+
             EditorGUILayout.BeginHorizontal();
             EditorGUILayout.BeginVertical();
 
@@ -454,26 +463,12 @@ namespace Unity.ProjectAuditor.Editor.UI
             if (m_ActiveAnalysisView.desc.showRightPanels)
             {
                 EditorGUILayout.BeginVertical(GUILayout.Width(LayoutSize.FoldoutWidth));
-                DrawFoldouts();
+                DrawFoldouts(problemDescriptor);
                 EditorGUILayout.EndVertical();
             }
 
             EditorGUILayout.EndHorizontal();
-        }
 
-        private void DrawFoldouts()
-        {
-            ProblemDescriptor problemDescriptor = null;
-            var selectedItems = m_ActiveIssueTable.GetSelectedItems();
-            var selectedDescriptors = selectedItems.Select(i => i.ProblemDescriptor);
-            var selectedIssues = selectedItems.Select(i => i.ProjectIssue);
-            // find out if all descriptors are the same
-            var firstDescriptor = selectedDescriptors.FirstOrDefault();
-            if (selectedDescriptors.Count() == selectedDescriptors.Count(d => d.id == firstDescriptor.id))
-                problemDescriptor = firstDescriptor;
-
-            DrawDetailsFoldout(problemDescriptor);
-            DrawRecommendationFoldout(problemDescriptor);
             if (m_ActiveAnalysisView.desc.showInvertedCallTree)
             {
                 ProjectIssue issue = null;
@@ -498,6 +493,12 @@ namespace Unity.ProjectAuditor.Editor.UI
 
                 DrawCallHierarchy(issue, callTree);
             }
+        }
+
+        private void DrawFoldouts(ProblemDescriptor problemDescriptor)
+        {
+            DrawDetailsFoldout(problemDescriptor);
+            DrawRecommendationFoldout(problemDescriptor);
         }
 
         private bool BoldFoldout(bool toggle, GUIContent content)
@@ -551,14 +552,14 @@ namespace Unity.ProjectAuditor.Editor.UI
 
         private void DrawCallHierarchy(ProjectIssue issue, CallTreeNode callTree)
         {
-            EditorGUILayout.BeginVertical(GUI.skin.box, GUILayout.Width(LayoutSize.FoldoutWidth));
+            EditorGUILayout.BeginVertical(GUI.skin.box, GUILayout.Height(LayoutSize.CallTreeHeight));
 
             m_Preferences.callTree = BoldFoldout(m_Preferences.callTree, Styles.CallTreeFoldout);
             if (m_Preferences.callTree)
             {
                 if (callTree != null)
                 {
-                    var r = EditorGUILayout.GetControlRect(GUILayout.Height(400));
+                    var r = EditorGUILayout.GetControlRect(GUILayout.ExpandHeight(true));
 
                     m_CallHierarchyView.OnGUI(r);
                 }
@@ -1065,6 +1066,7 @@ namespace Unity.ProjectAuditor.Editor.UI
             public static readonly int FilterOptionsLeftLabelWidth = 100;
             public static readonly int FilterOptionsEnumWidth = 50;
             public static readonly int ModeTabWidth = 300;
+            public static readonly int CallTreeHeight = 200;
         }
 
         private static class Styles


### PR DESCRIPTION
The call tree is currently shown in the right panels. Unfortunately, this means the space available to display the call tree hierarchy is quite limited.

Moving it at the bottom of the Window should solve this problem.
<img width="1027" alt="call-tree-layout" src="https://user-images.githubusercontent.com/12098182/96637090-1e178c00-1316-11eb-9131-3cf16ca97491.png">
