### PR TITLE
Only report issues related to the currently active build target

### DIFF
--- a/Data/ProjectSettings.json
+++ b/Data/ProjectSettings.json
@@ -27,6 +27,7 @@
             "method": "accelerometerFrequency",
             "customevaluator": "PlayerSettingsAccelerometerFrequency",
             "area": "CPU",
+            "platforms": ["ios"],
             "problem": "The Accelerometer is enabled in iOS Player Settings.",
             "solution": "Consider setting \"Accelerometer Frequency\" to Disabled if your application doesn't make use of the device's accelerometer. Disabling this option will save a tiny amount of CPU processing time."
         },
@@ -37,6 +38,7 @@
             "method": "GetArchitecture",
             "customevaluator": "PlayerSettingsArchitecture_iOS",
             "area": "BuildSize",
+            "platforms": ["ios"],
             "problem": "In the iOS Player Settings, \"Architecture\" is set to Universal. This means that the application will be compiled for both 32-bit ARMv7 iOS devices (i.e. up to the iPhone 5 or 5c) and 64-bit ARM64 devices (iPhone 5s onwards), resulting in increased build times and binary size.",
             "solution": "If your application isn't intended to support 32-bit iOS devices, change \"Architecture\" to ARM64."
         },
@@ -47,6 +49,7 @@
             "method": "Android.targetArchitectures",
             "customevaluator": "PlayerSettingsArchitecture_Android",
             "area": "BuildSize",
+            "platforms": ["android"],
             "problem": "In the Android Player Settings, in the \"Target Architecture\" section, both the \"ARMv7\" and \"ARM64\" options are selected. This means that the application will be compiled for both 32-bit ARMv7 Android devices and 64-bit ARM64 devices, resulting in increased build times and binary size.",
             "solution": "If your application isn't intended to support 32-bit Android devices, disable the \"ARMv7\" option."
         },
@@ -57,6 +60,7 @@
             "method": "GetGraphicsAPIs",
             "customevaluator": "PlayerSettingsGraphicsAPIs_iOS_OpenGLESAndMetal",
             "area": "BuildSize",
+            "platforms": ["ios"],
             "problem": "In the iOS Player Settings, both Metal and OpenGLES graphics APIs are enabled.",
             "solution": "To reduce build size, remove OpenGLES graphics API if the minimum spec target device supports Metal."
         },
@@ -67,6 +71,7 @@
             "method": "GetGraphicsAPIs",
             "customevaluator": "PlayerSettingsGraphicsAPIs_iOS_OpenGLES",
             "area": "CPU",
+            "platforms": ["ios"],
             "problem": "In the iOS Player Settings, Metal is not enabled.",
             "solution": "Enable Metal graphics API for better CPU Performance."
         },
@@ -107,6 +112,7 @@
             "method": "dataCaching",
             "value": "False",
             "area": "LoadTimes",
+            "platforms": ["webgl"],
             "problem": "Build file needs to be downloaded every time the content is loaded.",
             "solution": "Enable dataCaching to cache build files in Browser cache"
         },
@@ -117,6 +123,7 @@
             "method": "linkerTarget",
             "value": "Asm",
             "area": "CPU|Memory",
+            "platforms": ["webgl"],
             "problem": "WebGLLinkerTarget.Asm is deprecated.",
             "solution": "Set UnityEditor.PlayerSettings.WebGL.linkerTarget to WebGLLinkerTarget.Wasm to generate code in WebAssembly format."
         },
@@ -257,6 +264,7 @@
             "method": "GetManagedStrippingLevel",
             "customevaluator": "PlayerSettingsManagedCodeStripping_Android",
             "area": "BuildSize",
+            "platforms": ["android"],
             "problem": "Managed code stripping on Android is set to ManagedStrippingLevel.Low (or Disabled). The generated build will be larger than necessary.",
             "solution": "Set managed stripping level to Medium or High."
         },
@@ -267,6 +275,7 @@
             "method": "GetManagedStrippingLevel",
             "customevaluator": "PlayerSettingsManagedCodeStripping_iOS",
             "area": "BuildSize",
+            "platforms": ["ios"],
             "problem": "Managed code stripping on iOS is set to ManagedStrippingLevel.Low (or Disabled). The generated build will be larger than necessary.",
             "solution": "Set managed stripping level to Medium or High."
         },

--- a/Editor/ProblemDescriptor.cs
+++ b/Editor/ProblemDescriptor.cs
@@ -20,6 +20,7 @@ namespace Unity.ProjectAuditor.Editor
         public string method;
         public string value;
         public bool critical;
+        public string[] platforms;
         public string problem;
         public string solution;
 

--- a/Editor/Unity.ProjectAuditor.Editor.api
+++ b/Editor/Unity.ProjectAuditor.Editor.api
@@ -81,6 +81,7 @@ namespace Unity.ProjectAuditor.Editor
         public string description;
         public int id;
         public string method;
+        public string[] platforms;
         public string problem;
         public string solution;
         public string type;

--- a/Tests/Editor/PlatformTests.cs
+++ b/Tests/Editor/PlatformTests.cs
@@ -1,0 +1,25 @@
+using System.Linq;
+using NUnit.Framework;
+using Unity.ProjectAuditor.Editor;
+
+namespace UnityEditor.ProjectAuditor.EditorTests
+{
+    public class PlatformTests
+    {
+        [Test]
+        public void OnlyActiveBuildTargetIssuesAreReported()
+        {
+            Assert.True(EditorUserBuildSettings.activeBuildTarget != BuildTarget.iOS);
+
+            var projectAuditor = new Unity.ProjectAuditor.Editor.ProjectAuditor();
+
+            PlayerSettings.enableMetalAPIValidation = true;
+
+            var projectReport = projectAuditor.Audit();
+            var issues = projectReport.GetIssues(IssueCategory.ProjectSettings);
+
+            var enableMetalAPIValidationIssue = issues.FirstOrDefault(i => i.descriptor.method.Equals("enableMetalAPIValidation"));
+            Assert.Null(enableMetalAPIValidationIssue);
+        }
+    }
+}

--- a/Tests/Editor/PlatformTests.cs.meta
+++ b/Tests/Editor/PlatformTests.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 8b69bbfc1d8146ab999ed7fcf2d79e64
+timeCreated: 1603885201


### PR DESCRIPTION
Currently, Project Auditor reports code-related issues based on assemblies compiled for the active build target. However, when it comes to project settings, issues are reported regardless of the currently active platform. This PR makes project settings auditing consistent with the code one by only reporting issues valid for the current platform.